### PR TITLE
Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 omnipathr-log
 prove.R
+260413_1828_ProteinGroup_diaLFQ_fractionMerged_DIAGUI.txt

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="4d0ab15b-a42b-4613-a148-8ccebf203169" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="main" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "grandrea"
+  }
+}]]></component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/grandrea/QProMS.git",
+    "accountId": "72e50824-812f-493f-a23a-a42e460b8f4c"
+  }
+}]]></component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 6
+}]]></component>
+  <component name="ProjectId" id="3BXgI2h4mxqXIbhhWmSMyKpdmBj" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "ai.playground.ignore.import.keys.banner.in.settings": "true",
+    "git-widget-placeholder": "package",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-PY-253.31033.139" />
+        <option value="bundled-python-sdk-2653e85de345-6d6dccd035ac-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-253.31033.139" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="4d0ab15b-a42b-4613-a148-8ccebf203169" name="Changes" comment="" />
+      <created>1774640746498</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1774640746498</updated>
+      <workItem from="1774640747884" duration="90000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -910,14 +910,6 @@ QProMS <- R6Class(
         )
       return(t)
     },
-    get_trelliscope_path = function(name) {
-      root_dir <- file.path(tempdir(), "qproms_trelliscope")
-      dir.create(root_dir, showWarnings = FALSE, recursive = TRUE)
-      add_trelliscope_resource_path("trelliscope", root_dir)
-      plot_dir <- file.path(root_dir, name)
-      dir.create(plot_dir, showWarnings = FALSE, recursive = TRUE)
-      return(plot_dir)
-    },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
         e_bar(y) %>%
@@ -1345,7 +1337,9 @@ QProMS <- R6Class(
     plot_missval_distribution = function() {
       
       if(is.null(self$imputed_data)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("missval_distribution")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       p <- tibble("labels" = c("total", self$expdesign$label)) %>% 
         mutate(plots_panel = panel_lazy(self$plot_missval_distribution_internal)) %>% 
@@ -1703,7 +1697,9 @@ QProMS <- R6Class(
       
       if(is.null(self$normalized_data)){return(NULL)}
       if(nrow(self$expdesign) == 1){return(self$plot_empty_message("Not enough samples to compute the plot."))}
-      tr_dir <- self$get_trelliscope_path("multi_scatter")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       combinations <- t(combn(self$expdesign %>% pull(label), 2))
       colnames(combinations) <- c("x", "y")
       combinations <- as_tibble(combinations)
@@ -2172,7 +2168,9 @@ QProMS <- R6Class(
     plot_volcano = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("volcano")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2197,7 +2195,9 @@ QProMS <- R6Class(
     plot_ma = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("ma")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2274,7 +2274,9 @@ QProMS <- R6Class(
       if(is.null(genes) || length(genes) == 0){
         genes <- "NO_GENE_SELECTED"
       }
-      tr_dir <- self$get_trelliscope_path("stat_profile")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       x_all_genes <- rep(tests, each = length(genes))
       x_all_contrast <- rep(genes, length(tests))
       table <- tibble(
@@ -2541,7 +2543,9 @@ QProMS <- R6Class(
     },
     plot_cluster_profile = function() {
       if(is.null(self$anova_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("cluster_profile")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       clusters <- self$anova_table %>% distinct(cluster) %>% filter(cluster != "not_defined") %>% pull()
       colors <- viridis(n = length(clusters), option = self$palette)
@@ -3039,7 +3043,9 @@ QProMS <- R6Class(
     },
     plot_ora = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("ora")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3299,7 +3305,9 @@ QProMS <- R6Class(
     },
     plot_gsea = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("gsea")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -930,6 +930,152 @@ QProMS <- R6Class(
         ) %>%
         e_show_loading(text = "Loading...", color = self$primary_color)
     },
+    safe_report_plot = function(plot_fn, message = "Section not available for this analysis.") {
+      tryCatch(
+        plot_fn(),
+        error = function(e) {
+          self$plot_empty_message(message)
+        }
+      )
+    },
+    safe_report_table = function(table_fn, message = "Table not available for this analysis.") {
+      tryCatch(
+        {
+          table <- table_fn()
+          if (is.null(table)) {
+            return(
+              reactable(
+                tibble(Message = message),
+                compact = TRUE,
+                searchable = FALSE,
+                pagination = FALSE
+              )
+            )
+          }
+          table
+        },
+        error = function(e) {
+          reactable(
+            tibble(Message = message),
+            compact = TRUE,
+            searchable = FALSE,
+            pagination = FALSE
+          )
+        }
+      )
+    },
+    prepare_report_outputs = function() {
+      if (is.null(self$data)) {
+        return(invisible(NULL))
+      }
+      
+      if (is.null(self$rank_data) && !is.null(self$protein_rank_target)) {
+        tryCatch(
+          self$rank_protein(
+            target = self$protein_rank_target,
+            by_condition = self$protein_rank_by_cond,
+            selection = self$protein_rank_selection,
+            n_perc = self$protein_rank_top_n
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if (isTRUE(self$with_statistics) && is.null(self$stat_table) &&
+          !is.null(self$contrasts) && length(self$contrasts) > 0) {
+        tryCatch(
+          self$stat_uni_test(
+            test = self$contrasts,
+            fc = self$fold_change,
+            alpha = self$univariate_alpha,
+            p_adj_method = self$univariate_p_adj_method,
+            paired_test = self$univariate_paired,
+            test_type = self$univariate_test_type
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if (isTRUE(self$with_statistics) && is.null(self$anova_table)) {
+        tryCatch(
+          self$stat_anova(
+            alpha = self$anova_alpha,
+            p_adj_method = self$anova_p_adj_method
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if ((is.null(self$nodes_table) || is.null(self$edges_table)) &&
+          !is.null(self$network_from_statistic) && !is.null(self$pdb_database)) {
+        focus_net <- NULL
+        if (self$network_from_statistic == "univariate") {
+          focus_net <- self$network_focus_uni
+        } else if (self$network_from_statistic == "multivariate") {
+          focus_net <- self$network_focus_multi
+        } else if (self$network_from_statistic == "top_rank") {
+          focus_net <- "top_rank"
+        }
+        
+        tryCatch(
+          self$make_nodes(
+            list_from = self$network_from_statistic,
+            focus = focus_net,
+            direction = self$network_uni_direction
+          ),
+          error = function(e) NULL
+        )
+        tryCatch(
+          self$make_edges(source = self$pdb_database),
+          error = function(e) NULL
+        )
+      }
+      
+      if (is.null(self$ora_table) && !is.null(self$go_ora_from_statistic) &&
+          !is.null(self$go_ora_focus) && length(self$go_ora_focus) > 0) {
+        tryCatch(
+          {
+            self$go_ora(
+              list_from = self$go_ora_from_statistic,
+              focus = self$go_ora_focus,
+              database = self$go_ora_database,
+              ontology = self$go_ora_term,
+              simplify_thr = self$go_ora_simplify_thr,
+              alpha = self$go_ora_alpha,
+              p_adj_method = self$go_ora_p_adj_method,
+              min_gs_size = self$go_ora_min_gs_size,
+              max_gs_size = self$go_ora_max_gs_size,
+              background = self$go_ora_background
+            )
+            self$print_ora_table(self$go_ora_plot_arrenge)
+          },
+          error = function(e) NULL
+        )
+      }
+      
+      if (is.null(self$gsea_table) && !is.null(self$go_gsea_focus) && length(self$go_gsea_focus) > 0) {
+        tryCatch(
+          {
+            self$go_gsea(
+              test = self$go_gsea_focus,
+              rank_type = self$go_gsea_rank_with,
+              by_condition = self$go_gsea_by_cond,
+              database = self$go_gsea_database,
+              ontology = self$go_gsea_term,
+              simplify_thr = self$go_gsea_simplify_thr,
+              alpha = self$go_gsea_alpha,
+              p_adj_method = self$go_gsea_p_adj_method,
+              min_gs_size = self$go_gsea_min_gs_size,
+              max_gs_size = self$go_gsea_max_gs_size
+            )
+            self$print_gsea_table(self$go_gsea_plot_arrenge)
+          },
+          error = function(e) NULL
+        )
+      }
+      
+      invisible(NULL)
+    },
     plot_protein_counts = function() {
       
       if(is.null(self$filtered_data)){return(NULL)}
@@ -1271,8 +1417,30 @@ QProMS <- R6Class(
         column_to_rownames("gene_names") %>%
         as.matrix()
       
+      if (ncol(mat) < 2 || nrow(mat) == 0) {
+        return(self$plot_empty_message("Not enough data to compute PCA."))
+      }
+      
+      zero_var <- apply(mat, 2, function(x) {
+        vals <- x[!is.na(x)]
+        length(vals) == 0 || isTRUE(all.equal(stats::sd(vals), 0))
+      })
+      if (any(zero_var)) {
+        mat <- mat[, !zero_var, drop = FALSE]
+      }
+      
+      if (ncol(mat) < 2) {
+        return(self$plot_empty_message("PCA is not available because all remaining samples have constant values."))
+      }
+      
       ## perform PCA
-      pca <- prcomp(t(mat), center = TRUE, scale = TRUE) 
+      pca <- tryCatch(
+        prcomp(t(mat), center = TRUE, scale = TRUE),
+        error = function(e) NULL
+      )
+      if (is.null(pca) || is.null(pca$x) || ncol(pca$x) < 2) {
+        return(self$plot_empty_message("PCA is not available for this analysis."))
+      }
       
       ## calculate persentage of each PC
       pca_var <- pca$sdev^2
@@ -1282,7 +1450,7 @@ QProMS <- R6Class(
         label = rownames(pca$x),
         x = pca$x[, 1],
         y = pca$x[, 2],
-        z = pca$x[, 3]
+        z = if (ncol(pca$x) >= 3) pca$x[, 3] else 0
       ) %>% 
         left_join(self$expdesign, by = "label") 
       
@@ -1326,6 +1494,9 @@ QProMS <- R6Class(
           e_toolbox_feature(feature = c("saveAsImage", "restore")) %>% 
           e_show_loading(text = "Loading...", color = self$primary_color)
       }else{
+        if (ncol(pca$x) < 3) {
+          return(self$plot_empty_message("3D PCA is not available because fewer than three principal components were computed."))
+        }
         p <- pca_table %>%
           group_by(condition) %>%
           e_charts(x) %>%
@@ -1393,8 +1564,13 @@ QProMS <- R6Class(
         select(gene_names, label, intensity) %>%
         pivot_wider(id_cols = gene_names, names_from = label, values_from = intensity) %>%
         filter(if_all(.cols = everything(), .fns = ~ !is.na(.x))) %>%
-        column_to_rownames("gene_names") %>%
-        cor(method = self$cor_method) %>% 
+        column_to_rownames("gene_names")
+      
+      if (nrow(mat) == 0 || ncol(mat) < 2) {
+        return(self$plot_empty_message("Not enough complete data to compute the correlation matrix."))
+      }
+      
+      mat <- cor(mat, method = self$cor_method) %>% 
         round(digits = 2)
       
       p <- mat %>% 
@@ -3181,9 +3357,19 @@ QProMS <- R6Class(
       addStyle(excel, sheet = name, style = body_style, rows = 2:n_row, cols = 1:n_col, gridExpand = T)
       saveWorkbook(excel, handler, overwrite = T)
     },
-    download_table = function(handler_file, table_type, table_extension, extra_columns) {
+    sanitize_export_name = function(name, limit = 31) {
+      clean <- gsub("[^A-Za-z0-9_]+", "_", name)
+      clean <- gsub("_+", "_", clean)
+      clean <- gsub("^_|_$", "", clean)
+      if (nchar(clean) == 0) {
+        clean <- "table"
+      }
+      substr(clean, 1, limit)
+    },
+    exportable_table = function(table_type, extra_columns = NULL) {
       table <- switch(
         table_type,
+        "Filtered" = self$print_table(self$filtered_data, df = TRUE),
         "Filtred" = self$print_table(self$filtered_data, df = TRUE),
         "Normalized" = self$print_table(self$normalized_data, df = TRUE),
         "Imputed" = self$print_table(self$imputed_data, df = TRUE),
@@ -3202,10 +3388,63 @@ QProMS <- R6Class(
           select(gene_names, all_of(extra_columns))
         table <- left_join(table, extra, by = "gene_names")
       }
+      table
+    },
+    download_tables = function(handler_file, table_types, table_extension, extra_columns = NULL) {
+      tables <- map(table_types, ~ self$exportable_table(.x, extra_columns = extra_columns)) %>%
+        set_names(table_types) %>%
+        compact()
+      
+      if (length(tables) == 0) {
+        return(FALSE)
+      }
+      
+      if (length(tables) == 1) {
+        table_name <- names(tables)[1]
+        self$download_table(
+          handler_file = handler_file,
+          table_type = table_name,
+          table_extension = table_extension,
+          extra_columns = extra_columns
+        )
+        return(TRUE)
+      }
+      
+      if (table_extension != ".xlsx") {
+        return("multiple_requires_xlsx")
+      }
+      
+      header_style <- createStyle(
+        fontSize = 12,
+        fontColour = "#0f0f0f",
+        fgFill = "#faf2ca",
+        halign = "center",
+        border = "TopBottomLeftRight")
+      body_style <- createStyle(
+        halign = "center",
+        border = "TopBottomLeftRight")
+      excel <- createWorkbook()
+      for (table_name in names(tables)) {
+        sheet_name <- self$sanitize_export_name(table_name)
+        table <- tables[[table_name]]
+        addWorksheet(excel, sheetName = sheet_name, gridLines = FALSE)
+        writeDataTable(excel, sheet = sheet_name, x = table, keepNA = TRUE, na.string = "NaN")
+        n_row <- nrow(table) + 1
+        n_col <- ncol(table)
+        setColWidths(excel, sheet = sheet_name, cols = 1:n_col, widths = 21)
+        addStyle(excel, sheet = sheet_name, style = header_style, rows = 1, cols = 1:n_col, gridExpand = TRUE)
+        addStyle(excel, sheet = sheet_name, style = body_style, rows = 2:n_row, cols = 1:n_col, gridExpand = TRUE)
+      }
+      saveWorkbook(excel, handler_file, overwrite = TRUE)
+      TRUE
+    },
+    download_table = function(handler_file, table_type, table_extension, extra_columns) {
+      table <- self$exportable_table(table_type, extra_columns = extra_columns)
+      if(is.null(table)) {return(NULL)}
       switch(
         table_extension,
         ".xlsx" = self$download_excel(table, table_type, handler_file),
-        ".csv" = write.csv(table, handler_file),
+        ".csv" = write.csv(table, handler_file, row.names = FALSE),
         ".tsv" = write.table(table, handler_file, sep = "\t", row.names = FALSE, quote = FALSE)
       )
     },

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -808,6 +808,9 @@ QProMS <- R6Class(
       # -----------------------------
       else {
         self$is_imp <- FALSE
+        self$is_mixed <- FALSE
+        self$imputed_data <- self$normalized_data %>%
+          mutate(imputed = FALSE)
       }
       
       
@@ -815,8 +818,11 @@ QProMS <- R6Class(
       stopifnot(!all(is.na(self$imputed_data$intensity))) 
     },
     rank_protein = function(target, by_condition, selection, n_perc) {
+      data_source <- if (self$is_imp) self$imputed_data else self$normalized_data
+      if(is.null(data_source)){return(NULL)}
+      
       if(by_condition) {
-        data <- self$imputed_data %>%
+        data <- data_source %>%
           filter(condition == target) %>%
           group_by(gene_names) %>%
           summarise(mean_intenisty = mean(intensity)) %>%
@@ -826,7 +832,7 @@ QProMS <- R6Class(
           rename(intensity = mean_intenisty) %>% 
           select(gene_names, intensity, rank)
       } else {
-        data <- self$imputed_data %>%
+        data <- data_source %>%
           filter(label == target) %>%
           arrange(-intensity) %>%
           mutate(rank = rank(-intensity)) %>% 
@@ -903,6 +909,14 @@ QProMS <- R6Class(
           ))
         )
       return(t)
+    },
+    get_trelliscope_path = function(name) {
+      root_dir <- file.path(tempdir(), "qproms_trelliscope")
+      dir.create(root_dir, showWarnings = FALSE, recursive = TRUE)
+      add_trelliscope_resource_path("trelliscope", root_dir)
+      plot_dir <- file.path(root_dir, name)
+      dir.create(plot_dir, showWarnings = FALSE, recursive = TRUE)
+      return(plot_dir)
     },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
@@ -1185,10 +1199,7 @@ QProMS <- R6Class(
     plot_missval_distribution = function() {
       
       if(is.null(self$imputed_data)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("missval_distribution")
       
       p <- tibble("labels" = c("total", self$expdesign$label)) %>% 
         mutate(plots_panel = panel_lazy(self$plot_missval_distribution_internal)) %>% 
@@ -1516,10 +1527,7 @@ QProMS <- R6Class(
       
       if(is.null(self$normalized_data)){return(NULL)}
       if(nrow(self$expdesign) == 1){return(self$plot_empty_message("Not enough samples to compute the plot."))}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("multi_scatter")
       combinations <- t(combn(self$expdesign %>% pull(label), 2))
       colnames(combinations) <- c("x", "y")
       combinations <- as_tibble(combinations)
@@ -1771,22 +1779,6 @@ QProMS <- R6Class(
         select(gene_names, starts_with(test)) %>%
         rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
       
-      min_thr <- table %>%
-        filter(significant) %>%
-        pull(p_val) %>%
-        max(na.rm = TRUE)
-      
-      # Creare le linee di soglia per il grafico
-      left_line <- tibble(
-        p_val = c(-log10(min_thr), -log10(min_thr), max(-log10(table$p_val), na.rm = TRUE)),
-        fold_change = c(min(table$fold_change, na.rm = TRUE), -self$fold_change, -self$fold_change)
-      )
-      
-      right_line <- tibble(
-        p_val = c(max(-log10(table$p_val), na.rm = TRUE), -log10(min_thr), -log10(min_thr)),
-        fold_change = c(self$fold_change, max(table$fold_change, na.rm = TRUE), self$fold_change)
-      )
-      
       # Preparare il grafico
       p <- table %>%
         mutate(color = case_when(
@@ -1806,10 +1798,6 @@ QProMS <- R6Class(
       }
     ")) %>%
         e_add_nested("itemStyle", color) %>%
-        e_data(left_line, fold_change) %>%
-        e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
-        e_data(right_line, fold_change) %>%
-        e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
         e_toolbox_feature(feature = c("saveAsImage", "dataZoom")) %>%
         e_x_axis(
           name = "Difference (fold change)",
@@ -1834,6 +1822,29 @@ QProMS <- R6Class(
         e_grid(containLabel = TRUE) %>%
         e_group("grp") %>%
         e_show_loading(text = "Loading...", color = self$primary_color)
+      
+      if (any(table$significant, na.rm = TRUE)) {
+        min_thr <- table %>%
+          filter(significant) %>%
+          pull(p_val) %>%
+          max(na.rm = TRUE)
+        
+        left_line <- tibble(
+          p_val = c(-log10(min_thr), -log10(min_thr), max(-log10(table$p_val), na.rm = TRUE)),
+          fold_change = c(min(table$fold_change, na.rm = TRUE), -self$fold_change, -self$fold_change)
+        )
+        
+        right_line <- tibble(
+          p_val = c(max(-log10(table$p_val), na.rm = TRUE), -log10(min_thr), -log10(min_thr)),
+          fold_change = c(self$fold_change, max(table$fold_change, na.rm = TRUE), self$fold_change)
+        )
+        
+        p <- p %>%
+          e_data(left_line, fold_change) %>%
+          e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
+          e_data(right_line, fold_change) %>%
+          e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8))
+      }
       
       # Aggiungere punti di evidenziazione
       if (highlights_names != "") {
@@ -1985,10 +1996,7 @@ QProMS <- R6Class(
     plot_volcano = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("volcano")
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2013,10 +2021,7 @@ QProMS <- R6Class(
     plot_ma = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("ma")
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2093,10 +2098,7 @@ QProMS <- R6Class(
       if(is.null(genes) || length(genes) == 0){
         genes <- "NO_GENE_SELECTED"
       }
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("stat_profile")
       x_all_genes <- rep(tests, each = length(genes))
       x_all_contrast <- rep(genes, length(tests))
       table <- tibble(
@@ -2363,10 +2365,7 @@ QProMS <- R6Class(
     },
     plot_cluster_profile = function() {
       if(is.null(self$anova_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("cluster_profile")
       
       clusters <- self$anova_table %>% distinct(cluster) %>% filter(cluster != "not_defined") %>% pull()
       colors <- viridis(n = length(clusters), option = self$palette)
@@ -2864,10 +2863,7 @@ QProMS <- R6Class(
     },
     plot_ora = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("ora")
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3127,10 +3123,7 @@ QProMS <- R6Class(
     },
     plot_gsea = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("gsea")
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -51,6 +51,8 @@ QProMS <- R6Class(
     diann_sequences_parser = FALSE,
     log_transform = TRUE,
     organism = NULL, 
+    inputs_type_lists = NULL,
+    contaminants = NULL,
     expdesign = NULL,
     plot_format = "svg",
     plot_font_size = 16,
@@ -123,6 +125,8 @@ QProMS <- R6Class(
     # parameters For ORA #
     ora_result_list = NULL,
     ora_table = NULL,
+    ora_status = NULL,
+    ora_message = NULL,
     go_ora_from_statistic = NULL,
     go_ora_focus = NULL,
     go_ora_database = "GO",
@@ -166,6 +170,19 @@ QProMS <- R6Class(
     pdb_database = NULL,
     ###########
     # Methods #
+    initialize = function() {
+      pkg_dir <- system.file(package = "qproms")
+      
+      env1 <- new.env()
+      source(file.path(pkg_dir, "app/static/inputs_type_lists.R"), local = env1)
+      self$inputs_type_lists <- env1
+      
+      env2 <- new.env()
+      source(file.path(pkg_dir, "app/static/contaminants.R"), local = env2)
+      self$contaminants <- env2
+      
+      invisible(self)
+    },
     loading_data = function(input_path, input_name) {
       self$raw_data <- fread(input = input_path) 
       self$diann_sequences_parser <- FALSE
@@ -489,7 +506,7 @@ QProMS <- R6Class(
           mutate(!!gene_col := str_extract(.data[[gene_col]], "[^;]*")) %>% 
           mutate(!!gene_col := make.unique(.data[[gene_col]], sep = "_"))
       } else if (self$input_type == "ProteomeDiscoverer") {
-        org_map <- inputs_type_lists$org_map
+        org_map <- self$inputs_type_lists$org_map
         org_info <- org_map[[self$organism]]
         if (is.null(org_info)) return(NULL)
         orgdb     <- org_info$orgdb
@@ -2700,7 +2717,7 @@ QProMS <- R6Class(
       edges_string_table <- NULL
       edges_corum_table <- NULL
       if(is.null(self$nodes_table)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
       if (is.null(org_info)) return(NULL)
       tax_id <- org_info$tax_id
@@ -2951,11 +2968,27 @@ QProMS <- R6Class(
       }
       return(data)
     },
+    reset_ora_feedback = function() {
+      self$ora_status <- NULL
+      self$ora_message <- NULL
+    },
+    set_ora_feedback = function(status, message) {
+      self$ora_status <- status
+      self$ora_message <- message
+    },
     go_ora = function(list_from, focus, database, ontology, simplify_thr, alpha, p_adj_method, min_gs_size, max_gs_size, background) {
-      if(is.null(focus)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      self$reset_ora_feedback()
+      self$ora_result_list <- NULL
+      if(is.null(focus)){
+        self$set_ora_feedback("warning", "No ORA input was selected.")
+        return(NULL)
+      }
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
-      if (is.null(org_info)) return(NULL)
+      if (is.null(org_info)) {
+        self$set_ora_feedback("error", "ORA could not start because the selected organism is not configured.")
+        return(NULL)
+      }
       
       orgdb     <- org_info$orgdb
       kegg_org  <- org_info$kegg
@@ -3001,25 +3034,48 @@ QProMS <- R6Class(
       if (!background) {
         uni <- NULL
       }
+      gene_vector <- map(gene_vector, ~ unique(.x[!is.na(.x) & .x != "" & .x != "NO_Significant"]))
+      gene_counts <- lengths(gene_vector)
+      empty_groups <- names(gene_vector)[gene_counts == 0]
+      if (length(empty_groups) == length(gene_vector)) {
+        self$set_ora_feedback("warning", "No significant genes were available for the selected ORA input.")
+        return(NULL)
+      }
+      gene_vector_to_run <- gene_vector[gene_counts > 0]
+      ora_errors <- character()
+      run_ora_map <- function(named_vectors, enrich_fun) {
+        imap(named_vectors, function(genes, group_name) {
+          tryCatch(
+            enrich_fun(genes),
+            error = function(e) {
+              ora_errors[[group_name]] <<- conditionMessage(e)
+              NULL
+            }
+          )
+        })
+      }
       
       if (database == "GO") {
-        self$ora_result_list <- map(gene_vector, possibly(~ enrichGO(
-          gene = .x,
-          OrgDb = orgdb,
-          keyType = 'SYMBOL',
-          ont = ontology,
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size,
-          readable = TRUE) %>% 
-            clusterProfiler::filter(p.adjust < alpha) %>% 
-            simplify(cutoff = simplify_thr), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(gene_vector_to_run, function(genes) {
+          enrichGO(
+            gene = genes,
+            OrgDb = orgdb,
+            keyType = 'SYMBOL',
+            ont = ontology,
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size,
+            readable = TRUE
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha) %>%
+            simplify(cutoff = simplify_thr)
+        })
       }
       
       if (database == "KEGG") {
         entrez <- map(
-          gene_vector,
+          gene_vector_to_run,
           ~ bitr(
             .x,
             fromType = "SYMBOL",
@@ -3027,20 +3083,23 @@ QProMS <- R6Class(
             OrgDb    = orgdb
           ) %>% pull(ENTREZID)
         )
-        self$ora_result_list <- map(entrez, possibly(~ enrichKEGG(
-          gene = .x,
-          organism = kegg_org,
-          keyType = 'kegg',
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size) %>% 
-            clusterProfiler::filter(p.adjust < alpha), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(entrez, function(genes) {
+          enrichKEGG(
+            gene = genes,
+            organism = kegg_org,
+            keyType = 'kegg',
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha)
+        })
       }
       
       if (database == "WikiPathways") {
         entrez <- map(
-          gene_vector,
+          gene_vector_to_run,
           ~ bitr(
             .x,
             fromType = "SYMBOL",
@@ -3048,20 +3107,47 @@ QProMS <- R6Class(
             OrgDb    = orgdb
           ) %>% pull(ENTREZID)
         )
-        self$ora_result_list <- map(entrez, possibly(~ enrichWP(
-          gene = .x,
-          organism = wiki_org,
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size) %>% 
-            clusterProfiler::filter(p.adjust < alpha), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(entrez, function(genes) {
+          enrichWP(
+            gene = genes,
+            organism = wiki_org,
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha)
+        })
       }
-      
+      successful_groups <- names(compact(self$ora_result_list))
+      if (length(successful_groups) == 0) {
+        if (length(ora_errors) > 0) {
+          self$set_ora_feedback(
+            "error",
+            paste0("ORA failed during enrichment: ", paste(names(ora_errors), unname(ora_errors), sep = ": ", collapse = "; "))
+          )
+        } else {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
+        return(NULL)
+      }
+      messages <- character()
+      if (length(empty_groups) > 0) {
+        messages <- c(messages, paste0("No significant genes for: ", paste(empty_groups, collapse = ", ")))
+      }
+      if (length(ora_errors) > 0) {
+        messages <- c(messages, paste0("Enrichment failed for: ", paste(names(ora_errors), collapse = ", ")))
+      }
+      if (length(messages) > 0) {
+        self$set_ora_feedback("warning", paste(messages, collapse = ". "))
+      }
     },
     print_ora_table = function(arranged_with) {
       if(length(compact(self$ora_result_list)) == 0){
         self$ora_table <- NULL
+        if (is.null(self$ora_message)) {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
         return(NULL)
       }
       results_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
@@ -3069,11 +3155,15 @@ QProMS <- R6Class(
         as_tibble()
       if(nrow(results_table) == 0) {
         self$ora_table <- NULL
+        if (is.null(self$ora_message)) {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
         return(NULL)
       }
       required_cols <- c("GeneRatio", "BgRatio")
       if (!all(required_cols %in% names(results_table))) {
         self$ora_table <- NULL
+        self$set_ora_feedback("error", "ORA returned an unexpected result structure and could not be plotted.")
         return(NULL)
       }
       log_cols <- intersect(c("pvalue", "p.adjust", "qvalue"), names(results_table))
@@ -3246,7 +3336,7 @@ QProMS <- R6Class(
     },
     go_gsea = function(test, rank_type, by_condition, database, ontology, simplify_thr, alpha, p_adj_method, min_gs_size, max_gs_size) {
       if(is.null(test)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
       if (is.null(org_info)) return(NULL)
       

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -350,20 +350,21 @@ QProMS <- R6Class(
       
       return(reactable(summary_table))
     },
+    get_expdesign_intensity_cols = function(intensity_type) {
+      if(self$identify_table_status == "success") {
+        if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          return(self$get_diann_sequence_intensity_cols(self$raw_data))
+        }
+        return(grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE))
+      }
+      if(is.null(intensity_type)){intensity_type <- ""}
+      intensity_type
+    },
     make_expdesign = function(intensity_type) {
       
-      if(self$identify_table_status == "success") {
-        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
-          self$get_diann_sequence_intensity_cols(self$raw_data)
-        } else {
-          grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
-        }
-      } else {
-        if(is.null(intensity_type)){intensity_type <- ""}
-        intensity_cols <- intensity_type
-      }
+      intensity_cols <- self$get_expdesign_intensity_cols(intensity_type)
       
-      visible_rows <- min(length(intensity_cols), 24)
+      visible_rows <- max(min(length(intensity_cols), 16), 6)
       table_height <- 30 + (visible_rows * 23)
       
       table <- tibble("keep" = TRUE, "condition" = "", "key" = intensity_cols) %>% 

--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -48,6 +48,7 @@ QProMS <- R6Class(
     input_type = NULL,
     intensity_type = NULL,
     external_genes_column = NULL,
+    diann_sequences_parser = FALSE,
     log_transform = TRUE,
     organism = NULL, 
     expdesign = NULL,
@@ -167,6 +168,7 @@ QProMS <- R6Class(
     # Methods #
     loading_data = function(input_path, input_name) {
       self$raw_data <- fread(input = input_path) 
+      self$diann_sequences_parser <- FALSE
     },
     loading_parameters = function(input_path, self, print = FALSE) {
       parameters_list <- list.load(input_path)
@@ -221,6 +223,26 @@ QProMS <- R6Class(
         return(list(status = FALSE, message = "No Intensity columns found."))
       }
     },
+    get_diann_sequence_gene_col = function(data = self$raw_data) {
+      if ("Genes" %in% colnames(data)) {
+        return("Genes")
+      }
+      if ("Gene" %in% colnames(data)) {
+        return("Gene")
+      }
+      return(NULL)
+    },
+    get_diann_sequence_intensity_cols = function(data = self$raw_data) {
+      excluded_cols <- c("N.Sequences", "N.Proteotypic.Sequences", "Genes", "Gene", "Protein.Ids")
+      intensity_cols <- colnames(data)[sapply(data, is.numeric) & !colnames(data) %in% excluded_cols]
+      return(intensity_cols)
+    },
+    identify_diann_sequence_table = function(data = self$raw_data) {
+      has_sequence_col <- "N.Sequences" %in% colnames(data)
+      gene_col <- self$get_diann_sequence_gene_col(data)
+      intensity_cols <- self$get_diann_sequence_intensity_cols(data)
+      has_sequence_col && !is.null(gene_col) && length(intensity_cols) > 0
+    },
     identify_table_type = function() {
       data <- self$raw_data
       required_columns_list <- inputs_type_lists$metadata_list
@@ -228,6 +250,13 @@ QProMS <- R6Class(
       table_names <- names(required_columns_list)
       
       error_messages <- list()
+
+      if (self$identify_diann_sequence_table(data)) {
+        self$identify_table_status <- "success"
+        self$input_type <- "DIA-NN"
+        self$diann_sequences_parser <- TRUE
+        return(list(status = "success", message = "Table identified: DIA-NN"))
+      }
       
       for (i in seq_along(required_columns_list)) {
         table_name <- table_names[i]
@@ -244,6 +273,7 @@ QProMS <- R6Class(
         if (required_columns_check$status && intensity_columns_check$status) {
           self$identify_table_status <- "success"
           self$input_type <- table_name
+          self$diann_sequences_parser <- FALSE
           return(list(status = "success", message = paste("Table identified:", table_name)))
         } else {
           # Collect error messages
@@ -257,9 +287,13 @@ QProMS <- R6Class(
       # If no table type matches, return the collected error messages
       self$identify_table_status <- "info"
       self$input_type <- "External"
+      self$diann_sequences_parser <- FALSE
       return(list(status = "info", messages = error_messages))
     },
     check_intensity_regex = function() {
+      if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        return("DIA-NN sequence columns")
+      }
       regex_vec <- flatten_chr(inputs_type_lists$intensity_list %>% keep_at(self$input_type))
       
       found_regex <- sapply(regex_vec, function(regex) {
@@ -272,7 +306,11 @@ QProMS <- R6Class(
     create_summary_table = function() {
 
       data <- self$raw_data
-      required_columns <- inputs_type_lists$metadata_list[[self$input_type]][1]
+      required_columns <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        self$get_diann_sequence_gene_col(data)
+      } else {
+        inputs_type_lists$metadata_list[[self$input_type]][1]
+      }
       intensity_patterns <- self$check_intensity_regex()
       
       num_rows <- nrow(data)
@@ -286,7 +324,11 @@ QProMS <- R6Class(
       })
       
       missing_values_counts <- sapply(intensity_patterns, function(pattern) {
-        intensity_cols <- grep(pattern, colnames(data), value = TRUE)
+        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          self$get_diann_sequence_intensity_cols(data)
+        } else {
+          grep(pattern, colnames(data), value = TRUE)
+        }
         
         total_values <- length(unlist(data[, ..intensity_cols]))
         missing_values <- sum(is.na(data[, ..intensity_cols]) | data[, ..intensity_cols] == 0 | data[, ..intensity_cols] == "")
@@ -311,14 +353,21 @@ QProMS <- R6Class(
     make_expdesign = function(intensity_type) {
       
       if(self$identify_table_status == "success") {
-        intensity_cols <- grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
+        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          self$get_diann_sequence_intensity_cols(self$raw_data)
+        } else {
+          grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
+        }
       } else {
         if(is.null(intensity_type)){intensity_type <- ""}
         intensity_cols <- intensity_type
       }
       
+      visible_rows <- min(length(intensity_cols), 24)
+      table_height <- 30 + (visible_rows * 23)
+      
       table <- tibble("keep" = TRUE, "condition" = "", "key" = intensity_cols) %>% 
-        rhandsontable(width = "100%", stretchH = "all", height = 500) %>%
+        rhandsontable(width = "100%", stretchH = "all", height = table_height) %>%
         hot_col("key", readOnly = TRUE)
       
       return(table)
@@ -476,6 +525,14 @@ QProMS <- R6Class(
           ) %>% 
           mutate(gene_symbol = sub("_.*$", "", gene)) %>% 
           filter(!stringr::str_detect(db, "REV_")) %>% 
+          mutate(!!gene_col := self$make_unique_genes(.data[[gene_col]], .data[[protein_col]]))
+      } else if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        gene_col <- self$get_diann_sequence_gene_col(initial_table)
+        protein_col <- if ("Protein.Ids" %in% colnames(initial_table)) "Protein.Ids" else gene_col
+        required_columns <- unique(c(gene_col, protein_col))
+        initial_table <- initial_table %>%
+          mutate(!!gene_col := str_extract(.data[[gene_col]], "[^;]*")) %>%
+          mutate(!!protein_col := str_extract(.data[[protein_col]], "[^;]*")) %>%
           mutate(!!gene_col := self$make_unique_genes(.data[[gene_col]], .data[[protein_col]]))
       } else {
         required_columns <- inputs_type_lists$metadata_list[[self$input_type]]
@@ -909,6 +966,21 @@ QProMS <- R6Class(
           ))
         )
       return(t)
+    },
+    stat_table_for_test = function(test) {
+      if (is.null(self$stat_table) || is.null(test) || length(test) != 1 || is.na(test) || test == "") {
+        return(NULL)
+      }
+      suffixes <- c("fold_change", "p_val", "p_adj", "significant", "mean_abundance")
+      wanted <- paste0(test, "_", suffixes)
+      existing <- intersect(wanted, colnames(self$stat_table))
+      if (length(existing) == 0) {
+        return(NULL)
+      }
+      table <- self$stat_table %>%
+        select(all_of(c("gene_names", existing)))
+      names(table)[-1] <- sub(paste0(test, "_"), "", names(table)[-1], fixed = TRUE)
+      table
     },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
@@ -1947,9 +2019,10 @@ QProMS <- R6Class(
         ceiling()
       
       # Preparare la tabella dei dati
-      table <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
+      table <- self$stat_table_for_test(test)
+      if (is.null(table)) {
+        return(self$plot_empty_message("Selected contrast is not available."))
+      }
       
       # Preparare il grafico
       p <- table %>%
@@ -2075,9 +2148,10 @@ QProMS <- R6Class(
         max(na.rm = TRUE) %>%
         ceiling()
       
-      table <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
+      table <- self$stat_table_for_test(test)
+      if (is.null(table)) {
+        return(self$plot_empty_message("Selected contrast is not available."))
+      }
       
       p <- table %>%
         mutate(color = case_when(
@@ -2849,15 +2923,25 @@ QProMS <- R6Class(
     make_ora_list_internal = function(focus) {
       if((is.null(self$stat_table) || is.null(focus))){return(NULL)}
       test <- str_remove(focus, pattern = "_up|_down")
-      data <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_"))) %>%
-        filter(significant)
+      data <- self$stat_table_for_test(test)
+      if (is.null(data) || !all(c("gene_names", "fold_change", "significant") %in% names(data))) {
+        return(tibble(
+          gene_names = c("NO_Significant", "NO_Significant"),
+          direction = c(paste0(test, "_up"), paste0(test, "_down"))
+        ))
+      }
+      data <- data %>% filter(significant)
       if(nrow(data) > 0) {
         data <- data %>%
           mutate(direction = if_else(fold_change > 0, paste0(test, "_up"), paste0(test, "_down"))) %>%
           filter(direction == focus) %>% 
           select(gene_names, direction) 
+        if (nrow(data) == 0) {
+          data <- tibble(
+            gene_names = "NO_Significant",
+            direction = focus
+          )
+        }
       } else {
         data <- tibble(
           gene_names = c("NO_Significant", "NO_Significant"),
@@ -2979,22 +3063,25 @@ QProMS <- R6Class(
         self$ora_table <- NULL
         return(NULL)
       }
-      empty <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
+      results_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
         list_rbind(names_to = "group") %>% 
-        as_tibble() %>% 
-        nrow()
-      if(empty == 0) {
+        as_tibble()
+      if(nrow(results_table) == 0) {
         self$ora_table <- NULL
         return(NULL)
       }
-      self$ora_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
-        list_rbind(names_to = "group") %>% 
-        as_tibble() %>% 
+      required_cols <- c("GeneRatio", "BgRatio")
+      if (!all(required_cols %in% names(results_table))) {
+        self$ora_table <- NULL
+        return(NULL)
+      }
+      log_cols <- intersect(c("pvalue", "p.adjust", "qvalue"), names(results_table))
+      self$ora_table <- results_table %>% 
         separate(GeneRatio, into = c("a", "b"), sep = "/", remove = FALSE) %>%
         separate(BgRatio, into = c("c", "d"), sep = "/", remove = FALSE) %>%
         mutate(
           fold_enrichment = (as.numeric(a) / as.numeric(b)) / (as.numeric(c) / as.numeric(d)),
-          across(c("pvalue", "p.adjust", "qvalue"), ~ round(-log10(.), 3)),
+          across(all_of(log_cols), ~ round(-log10(.), 3)),
           fold_enrichment = round(fold_enrichment, 3)
         ) %>%
         select(-c(a, b, c, d)) %>% 
@@ -3045,7 +3132,7 @@ QProMS <- R6Class(
       if(is.null(groups)){return(NULL)}
       tr_dir <- tempfile()
       dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      add_trelliscope_resource_path("trelliscope_ora", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3054,8 +3141,8 @@ QProMS <- R6Class(
       )
       p <- table %>% 
         mutate(plots_panel = panel_lazy(self$plot_ora_single)) %>% 
-        as_trelliscope_df(name = "BarPlot",
-                          path = file.path(tr_dir, "test"),
+        as_trelliscope_df(name = "ORA_BarPlot",
+                          path = file.path(tr_dir, "ora_plot"),
                           jsonp = FALSE) %>% 
         set_default_layout(ncol = n_col)
       
@@ -3307,7 +3394,7 @@ QProMS <- R6Class(
       if(is.null(groups)){return(NULL)}
       tr_dir <- tempfile()
       dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      add_trelliscope_resource_path("trelliscope_gsea", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3316,8 +3403,8 @@ QProMS <- R6Class(
       )
       p <- table %>% 
         mutate(plots_panel = panel_lazy(self$plot_gsea_single)) %>% 
-        as_trelliscope_df(name = "BarPlot",
-                          path = file.path(tr_dir, "test"),
+        as_trelliscope_df(name = "GSEA_BarPlot",
+                          path = file.path(tr_dir, "gsea_plot"),
                           jsonp = FALSE) %>% 
         set_default_layout(ncol = n_col)
       

--- a/app/logic/Report_QProMS.qmd
+++ b/app/logic/Report_QProMS.qmd
@@ -46,12 +46,30 @@ suppressPackageStartupMessages(library(reactable))
 ```{r}
 #| label: "upload session"
 
-box::use(app/logic/R6Class_QProMS)
-r6 <- R6Class_QProMS$QProMS$new()
-# Remove the comment below to download the report locally
-# param_list <- r6$loading_parameters(input_path = here("app/logic/QProMS_session_internal.rds"), self = r6, print = TRUE)
-# This line loads the report from the server path (for production use)
-param_list <- r6$loading_parameters(input_path = "/srv/shiny-server/app/logic/QProMS_session_internal.rds", self = r6, print = TRUE)
+# Load R6 class directly (we're already in the right directory context)
+pkg_dir <- system.file(package = "qproms")
+source(file.path(pkg_dir, "app/logic/R6Class_QProMS.R"), local = TRUE)
+
+r6 <- QProMS$new()
+
+# Load parameters
+rds_path <- file.path(pkg_dir, "app/logic/QProMS_session_internal.rds")
+param_list <- r6$loading_parameters(input_path = rds_path, self = r6, print = TRUE)
+r6$prepare_report_outputs()
+
+safe_panel_plots <- function(items, plot_fn, message) {
+  if (is.null(items) || length(items) == 0) {
+    return(list(placeholder = r6$plot_empty_message(message)))
+  }
+  plots <- map(
+    items,
+    ~ r6$safe_report_plot(
+      function() plot_fn(.x),
+      message = message
+    )
+  )
+  set_names(plots, items)
+}
 ```
 
 ```{r}
@@ -71,21 +89,26 @@ The following table presents an overview of the experimental design employed in 
 ```{r}
 #| label: "expdesign"
 
-r6$expdesign %>%
-  select(
-    Key = key,
-    Label = label,
-    Condition = condition,
-    Replicate = replicate
-  ) %>%
-  reactable(
-    wrap = FALSE,
-    striped = TRUE,
-    resizable = TRUE,
-    compact = TRUE,
-    height = "auto",
-    paginationType = "simple",
-  )
+r6$safe_report_table(
+  function() {
+    r6$expdesign %>%
+      select(
+        Key = key,
+        Label = label,
+        Condition = condition,
+        Replicate = replicate
+      ) %>%
+      reactable(
+        wrap = FALSE,
+        striped = TRUE,
+        resizable = TRUE,
+        compact = TRUE,
+        height = "auto",
+        paginationType = "simple"
+      )
+  },
+  message = "Experimental design is not available."
+)
 ```
 
 `r if(!params$Preprocessing) "::: {.content-hidden}"`
@@ -102,7 +125,7 @@ The following section presents a series of interactive quality control (QC) grap
 #| label: "count"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_protein_counts()
+r6$safe_report_plot(function() r6$plot_protein_counts(), "Protein counts are not available for this analysis.")
 ```
 
 ### Distribution
@@ -111,7 +134,7 @@ r6$plot_protein_counts()
 #| label: "distribution"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_distribution()
+r6$safe_report_plot(function() r6$plot_distribution(), "Distribution plot is not available for this analysis.")
 ```
 
 ### Upset Plot
@@ -120,7 +143,7 @@ r6$plot_distribution()
 #| label: "upset"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_protein_coverage()
+r6$safe_report_plot(function() r6$plot_protein_coverage(), "Upset plot is not available for this analysis.")
 ```
 
 ### CV
@@ -129,7 +152,7 @@ r6$plot_protein_coverage()
 #| label: "cv"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_cv()
+r6$safe_report_plot(function() r6$plot_cv(), "CV plot is not available for this analysis.")
 ```
 
 ### Missing Data
@@ -138,7 +161,7 @@ r6$plot_cv()
 #| label: "missing data"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_missing_data()
+r6$safe_report_plot(function() r6$plot_missing_data(), "Missing-data plot is not available for this analysis.")
 ```
 
 ### Imputed
@@ -147,7 +170,7 @@ r6$plot_missing_data()
 #| label: "imputed"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_missval_distribution_internal("total")
+r6$safe_report_plot(function() r6$plot_missval_distribution_internal("total"), "Imputation distribution is not available for this analysis.")
 ```
 
 :::
@@ -166,7 +189,7 @@ The x-axis (PC1) and y-axis (PC2) represent the first two principal components, 
 #| label: "pca"
 #| eval: !expr if(params$PCA) TRUE else FALSE
 
-r6$plot_pca()
+r6$safe_report_plot(function() r6$plot_pca(), "PCA is not available for this analysis.")
 ```
 
 `r if(!params$PCA) ":::"`
@@ -181,7 +204,7 @@ The following heatmap illustrates the correlation between all samples included i
 #| label: "correlation"
 #| eval: !expr if(params$Correlation) TRUE else FALSE
 
-r6$plot_correlation()
+r6$safe_report_plot(function() r6$plot_correlation(), "Correlation heatmap is not available for this analysis.")
 ```
 
 `r if(!params$Correlation) ":::"`
@@ -198,7 +221,7 @@ This plot is particularly useful for identifying highly expressed proteins that 
 #| label: "rank"
 #| eval: !expr if(params$Rank) TRUE else FALSE
 
-r6$plot_protein_rank()
+r6$safe_report_plot(function() r6$plot_protein_rank(), "Rank plot is not available for this analysis.")
 ```
 
 `r if(!params$Rank) ":::"`
@@ -221,16 +244,18 @@ This plot helps to quickly identify key proteins that are differentially express
 #| label: "volcano generation"
 #| eval: !expr if(Volcano_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$contrasts,
-  .f = ~ r6$plot_volcano_single(
-    test = .x,
-    highlights_names = "",
-    same_x = r6$univariate_same_x,
-    same_y = r6$univariate_same_y
-  )
-) %>%
-  set_names(r6$contrasts)
+plots <- safe_panel_plots(
+  r6$contrasts,
+  function(.x) {
+    r6$plot_volcano_single(
+      test = .x,
+      highlights_names = "",
+      same_x = r6$univariate_same_x,
+      same_y = r6$univariate_same_y
+    )
+  },
+  "Volcano plots are not available for this analysis."
+)
 ```
 
 ```{r}
@@ -264,7 +289,7 @@ This heatmap serves as a powerful tool for identifying proteins that are signifi
 #| label: "heatmap"
 #| eval: !expr if(Heatmap_param) TRUE else FALSE
 
-r6$plot_heatmap(order_by_expdesing = r6$anova_manual_order)
+r6$safe_report_plot(function() r6$plot_heatmap(order_by_expdesing = r6$anova_manual_order), "Heatmap is not available for this analysis.")
 ```
 
 `r if(!Heatmap_param) ":::"`
@@ -285,14 +310,17 @@ In the network visualization, edges from STRING are colored in gray, while edges
 #| label: "network"
 #| eval: !expr if(Network_param) TRUE else FALSE
 
-r6$plot_ppi_network(
-  list_from = r6$network_from_statistic,
-  score_thr = r6$network_score_thr,
-  isolate_nodes = FALSE,
-  layout = "force",
-  show_names = TRUE,
-  selected = NULL,
-  filtered = FALSE
+r6$safe_report_plot(
+  function() r6$plot_ppi_network(
+    list_from = r6$network_from_statistic,
+    score_thr = r6$network_score_thr,
+    isolate_nodes = FALSE,
+    layout = "force",
+    show_names = TRUE,
+    selected = NULL,
+    filtered = FALSE
+  ),
+  "Network plot is not available for this analysis."
 )
 ```
 
@@ -312,15 +340,17 @@ These GO terms help to contextualize the proteomic data within broader biologica
 #| label: "ora generation"
 #| eval: !expr if(ORA_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$go_ora_focus,
-  .f = ~ r6$plot_ora_single(
-    focus = .x,
-    arrange = r6$go_ora_plot_arrenge,
-    show_category = r6$go_ora_top_n
-  )
-) %>%
-  set_names(r6$go_ora_focus)
+plots <- safe_panel_plots(
+  r6$go_ora_focus,
+  function(.x) {
+    r6$plot_ora_single(
+      focus = .x,
+      arrange = r6$go_ora_plot_arrenge,
+      show_category = r6$go_ora_top_n
+    )
+  },
+  "ORA plots are not available for this analysis."
+)
 ```
 
 ```{r}
@@ -356,15 +386,17 @@ The GSEA results provide valuable insights into the biological pathways and proc
 #| label: "gsea generation"
 #| eval: !expr if(GSEA_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$go_gsea_focus,
-  .f = ~ r6$plot_gsea_single(
-    focus = .x,
-    arrange = r6$go_gsea_plot_arrenge,
-    show_category = r6$go_gsea_top_n
-  )
-) %>%
-  set_names(r6$go_gsea_focus)
+plots <- safe_panel_plots(
+  r6$go_gsea_focus,
+  function(.x) {
+    r6$plot_gsea_single(
+      focus = .x,
+      arrange = r6$go_gsea_plot_arrenge,
+      show_category = r6$go_gsea_top_n
+    )
+  },
+  "GSEA plots are not available for this analysis."
+)
 ```
 
 ```{r}

--- a/app/view/download.R
+++ b/app/view/download.R
@@ -1,5 +1,5 @@
 box::use(
-  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput, checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate],
+  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput, checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate, showNotification],
   bslib[page_fillable, layout_columns, card, card_header, card_body, accordion, accordion_panel, nav_select, tooltip],
   gargoyle[init, watch, trigger],
   quarto[quarto_render],
@@ -39,13 +39,14 @@ ui <- function(id) {
             col_widths = c(6, 3, 3),
             selectInput(
               ns("select_table"),
-              "Table",
+              "Tables",
               choices = list(
                 "Preprocessing" = c("Filtered", "Normalized", "Imputed"),
                 "Statistical analysis" = c("Ranked", "Volcano"),
                 "Visualization data" = c("Heatmap", "Nodes", "Edges"),
                 "Functional enrichment" = c("ORA", "GSEA")
               ),
+              multiple = TRUE,
               width = "100%"
             ),
             selectInput(
@@ -65,8 +66,8 @@ ui <- function(id) {
             ),
             conditionalPanel(
               condition = "input.include_metadata === true &&
-                          ['Filtered','Normalized','Imputed','Volcano','Heatmap']
-                          .includes(input.select_table)",
+                          Array.isArray(input.select_table) &&
+                          input.select_table.some(x => ['Filtered','Normalized','Imputed','Volcano','Heatmap','Ranked'].includes(x))",
               ns = ns,
               selectInput(
                 ns("add_metadata"),
@@ -202,12 +203,25 @@ server <- function(id, r6) {
       }
     })
     
+    observeEvent(input$select_table, {
+      if (length(input$select_table) > 1 && !identical(input$table_extension, ".xlsx")) {
+        updateSelectInput(inputId = "table_extension", selected = ".xlsx")
+        showNotification("Multiple tables are exported together as an .xlsx workbook.", type = "message")
+      }
+    }, ignoreNULL = TRUE)
+    
     output$download_table <- downloadHandler(
       filename = function() {
-        paste0(input$select_table, "_table_", Sys.Date(), input$table_extension)
+        selected_tables <- isolate(input$select_table)
+        if (is.null(selected_tables) || length(selected_tables) == 0) {
+          return(paste0("QProMS_tables_", Sys.Date(), ".xlsx"))
+        }
+        if (length(selected_tables) == 1) {
+          return(paste0(selected_tables[[1]], "_table_", Sys.Date(), input$table_extension))
+        }
+        paste0("QProMS_tables_", Sys.Date(), ".xlsx")
       },
       content = function(file) {
-        
         if (is.null(r6$data)) {
           shinyalert(
             title = "No data loaded",
@@ -217,28 +231,43 @@ server <- function(id, r6) {
           return(invisible(NULL))
         }
         
-        selected_table <- input$select_table
-        table_data     <- get_table_from_r6(selected_table)
-        
-        if (is.null(table_data)) {
+        selected_tables <- input$select_table
+        if (is.null(selected_tables) || length(selected_tables) == 0) {
           shinyalert(
-            title = "Table not available",
-            text  = paste0(
-              "The '", selected_table, "' table has not been generated yet. ",
-              "Please complete the corresponding analysis step first."
-            ),
+            title = "No tables selected",
+            text  = "Please select at least one table to export.",
             type  = "warning"
           )
           return(invisible(NULL))
         }
         
-        # --- Tutto ok: procedi con il download ---
-        r6$download_table(
-          handler_file    = file,
-          table_type      = selected_table,
+        ok <- r6$download_tables(
+          handler_file = file,
+          table_types = selected_tables,
           table_extension = input$table_extension,
-          extra_columns   = input$add_metadata
+          extra_columns = input$add_metadata
         )
+        
+        if (identical(ok, "multiple_requires_xlsx")) {
+          showNotification("Exporting multiple tables at once is available only as an .xlsx workbook.", type = "warning")
+          return(invisible(NULL))
+        }
+        
+        if (!isTRUE(ok)) {
+          if (length(selected_tables) == 1 && is.null(get_table_from_r6(selected_tables[[1]]))) {
+            shinyalert(
+              title = "Table not available",
+              text  = paste0(
+                "The '", selected_tables[[1]], "' table has not been generated yet. ",
+                "Please complete the corresponding analysis step first."
+              ),
+              type  = "warning"
+            )
+          } else {
+            showNotification("No selected tables are available for export.", type = "warning")
+          }
+          return(invisible(NULL))
+        }
       }
     )
     

--- a/app/view/ora.R
+++ b/app/view/ora.R
@@ -1,5 +1,5 @@
 box::use(
-  shiny[moduleServer, NS, selectInput, br, sliderInput, actionButton, updateSliderInput, updateNumericInput, isolate, icon, observe, updateSelectInput, updateSelectizeInput, reactive, observeEvent, numericInput, conditionalPanel, selectizeInput],
+  shiny[moduleServer, NS, selectInput, br, sliderInput, actionButton, updateSliderInput, updateNumericInput, isolate, icon, observe, updateSelectInput, updateSelectizeInput, reactive, observeEvent, numericInput, conditionalPanel, selectizeInput, showNotification],
   bslib[page_sidebar, layout_columns, navset_card_underline, nav_panel, update_switch, sidebar, accordion, accordion_panel, input_switch, tooltip, input_task_button],
   gargoyle[watch, trigger],
   trelliscope[trelliscopeOutput, renderTrelliscope],
@@ -246,6 +246,22 @@ ui <- function(id) {
 #' @export
 server <- function(id, r6, main_session) {
   moduleServer(id, function(input, output, session) {
+    render_ora_outputs <- function(message = NULL) {
+      if (!is.null(message)) {
+        showNotification(message, type = "warning")
+      }
+      output$bar_plot <- renderTrelliscope({
+        focus_plot <- r6$go_ora_focus
+        if (is.null(focus_plot) || length(focus_plot) == 0) {
+          focus_plot <- "manual"
+        }
+        if(r6$go_ora_from_statistic == "manual") {focus_plot <- "manual"}
+        r6$plot_ora(focus_plot, r6$go_ora_plot_arrenge, r6$go_ora_top_n)
+      })
+      output$table <- renderReactable({
+        r6$reactable_functional_analysis(r6$ora_table)
+      })
+    }
     
     observe({
       watch("stat")
@@ -362,18 +378,12 @@ server <- function(id, r6, main_session) {
         )
         r6$print_ora_table(r6$go_ora_plot_arrenge)
       }, error = function(e) {
-        return(NULL)
+        r6$ora_result_list <- NULL
+        r6$ora_table <- NULL
+        render_ora_outputs("ORA could not be generated for the selected input.")
+        return(invisible(NULL))
       })
-      output$bar_plot <- renderTrelliscope({
-        if(!is.null(r6$ora_result_list)) {
-          focus_plot <- r6$go_ora_focus
-          if(r6$go_ora_from_statistic == "manual") {focus_plot <- "manual"}
-          r6$plot_ora(focus_plot, r6$go_ora_plot_arrenge, r6$go_ora_top_n)
-        }
-      })
-      output$table <- renderReactable({
-        r6$reactable_functional_analysis(r6$ora_table)
-      })
+      render_ora_outputs()
     })
   })
 }

--- a/app/view/ora.R
+++ b/app/view/ora.R
@@ -246,9 +246,9 @@ ui <- function(id) {
 #' @export
 server <- function(id, r6, main_session) {
   moduleServer(id, function(input, output, session) {
-    render_ora_outputs <- function(message = NULL) {
+    render_ora_outputs <- function(message = NULL, notification_type = "warning") {
       if (!is.null(message)) {
-        showNotification(message, type = "warning")
+        showNotification(message, type = notification_type)
       }
       output$bar_plot <- renderTrelliscope({
         focus_plot <- r6$go_ora_focus
@@ -380,10 +380,18 @@ server <- function(id, r6, main_session) {
       }, error = function(e) {
         r6$ora_result_list <- NULL
         r6$ora_table <- NULL
-        render_ora_outputs("ORA could not be generated for the selected input.")
+        r6$set_ora_feedback("error", paste("ORA failed:", conditionMessage(e)))
+        render_ora_outputs(r6$ora_message, "error")
         return(invisible(NULL))
       })
-      render_ora_outputs()
+      ora_status <- if (length(r6$ora_status) == 1 && !is.na(r6$ora_status)) r6$ora_status else ""
+      notification_type <- switch(
+        ora_status,
+        error = "error",
+        warning = "warning",
+        "message"
+      )
+      render_ora_outputs(r6$ora_message, notification_type)
     })
   })
 }

--- a/app/view/upload.R
+++ b/app/view/upload.R
@@ -152,10 +152,21 @@ server <- function(id, r6, main_session) {
                 "Select Gene Column",
                 choices = colnames(r6$raw_data)[sapply(r6$raw_data, is.character)]
               ),
-              textInput(
-                ns("intensity_pattern"),
-                "Filter intensity columns (regex or keyword)",
-                placeholder = "e.g. LFQ|Intensity|Sample_"
+              layout_columns(
+                col_widths = c(9, 3),
+                textInput(
+                  ns("intensity_pattern"),
+                  "Filter intensity columns (regex or keyword)",
+                  placeholder = "e.g. LFQ|Intensity|Sample_"
+                ),
+                div(
+                  style = "margin-top: 1.8rem;",
+                  input_switch(
+                    id = ns("auto_select_pattern"),
+                    label = "Auto-select",
+                    value = TRUE
+                  )
+                )
               ),
               selectizeInput(
                 ns("intensity_columns"),
@@ -215,15 +226,21 @@ server <- function(id, r6, main_session) {
           value = TRUE,
           ignore.case = TRUE
         )
+        selected <- if (isTRUE(input$auto_select_pattern)) {
+          filtered
+        } else {
+          intersect(input$intensity_columns, filtered)
+        }
       } else {
         filtered <- all_numeric
+        selected <- intersect(input$intensity_columns, filtered)
       }
       
       updateSelectizeInput(
         session,
         "intensity_columns",
         choices = filtered,
-        selected = intersect(input$intensity_columns, filtered),
+        selected = selected,
         server = TRUE
       )
     })

--- a/app/view/upload.R
+++ b/app/view/upload.R
@@ -60,7 +60,10 @@ ui <- function(id) {
       nav_panel(
         title = "Experimental Design",
         layout_sidebar(
-          rHandsontableOutput(ns("exp_design")),
+          div(
+            uiOutput(ns("exp_design_info")),
+            rHandsontableOutput(ns("exp_design"))
+          ),
           sidebar = sidebar(
             width = 300,
             actionButton(
@@ -92,6 +95,8 @@ server <- function(id, r6, main_session) {
     
     ns <- session$ns
     init("genes")
+    
+    output$exp_design_info <- renderUI({NULL})
     
     observe({
       watch("session")
@@ -247,14 +252,30 @@ server <- function(id, r6, main_session) {
     
     observeEvent(input$confirm2, {
       if(!is.null(r6$raw_data) & r6$new_session) {
+        intensity_input <- if(r6$identify_table_status == "success") {
+          input$intensity_type
+        } else {
+          r6$external_genes_column <- input$metadata_column
+          input$intensity_columns
+        }
+        intensity_cols <- r6$get_expdesign_intensity_cols(intensity_input)
+        output$exp_design_info <- renderUI({
+          hint_text <- if (length(intensity_cols) > 16) {
+            "Scroll inside the table to review all rows."
+          } else {
+            "All rows fit in the current view."
+          }
+          div(
+            class = "alert alert-secondary",
+            style = "padding: 0.6rem 0.9rem; margin-bottom: 0.75rem;",
+            tags$strong(paste(length(intensity_cols), "samples in the design table")),
+            br(),
+            tags$span(hint_text)
+          )
+        })
         nav_select("upload_container", "Experimental Design")
         output$exp_design <- renderRHandsontable({
-          if(r6$identify_table_status == "success") {
-            r6$make_expdesign(input$intensity_type)
-          } else {
-            r6$external_genes_column <- input$metadata_column
-            r6$make_expdesign(input$intensity_columns)
-          }
+          r6$make_expdesign(intensity_input)
         })
       }
     })

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -822,6 +822,9 @@ QProMS <- R6Class(
       # -----------------------------
       else {
         self$is_imp <- FALSE
+        self$is_mixed <- FALSE
+        self$imputed_data <- self$normalized_data %>%
+          mutate(imputed = FALSE)
       }
   
       
@@ -829,8 +832,11 @@ QProMS <- R6Class(
       stopifnot(!all(is.na(self$imputed_data$intensity))) 
     },
     rank_protein = function(target, by_condition, selection, n_perc) {
+      data_source <- if (self$is_imp) self$imputed_data else self$normalized_data
+      if(is.null(data_source)){return(NULL)}
+      
       if(by_condition) {
-        data <- self$imputed_data %>%
+        data <- data_source %>%
           filter(condition == target) %>%
           group_by(gene_names) %>%
           summarise(mean_intenisty = mean(intensity)) %>%
@@ -840,7 +846,7 @@ QProMS <- R6Class(
           rename(intensity = mean_intenisty) %>% 
           select(gene_names, intensity, rank)
       } else {
-        data <- self$imputed_data %>%
+        data <- data_source %>%
           filter(label == target) %>%
           arrange(-intensity) %>%
           mutate(rank = rank(-intensity)) %>% 

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -924,14 +924,6 @@ QProMS <- R6Class(
         )
       return(t)
     },
-    get_trelliscope_path = function(name) {
-      root_dir <- file.path(tempdir(), "qproms_trelliscope")
-      dir.create(root_dir, showWarnings = FALSE, recursive = TRUE)
-      add_trelliscope_resource_path("trelliscope", root_dir)
-      plot_dir <- file.path(root_dir, name)
-      dir.create(plot_dir, showWarnings = FALSE, recursive = TRUE)
-      return(plot_dir)
-    },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
         e_bar(y) %>%
@@ -1359,7 +1351,9 @@ QProMS <- R6Class(
     plot_missval_distribution = function() {
       
       if(is.null(self$imputed_data)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("missval_distribution")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       p <- tibble("labels" = c("total", self$expdesign$label)) %>% 
         mutate(plots_panel = panel_lazy(self$plot_missval_distribution_internal)) %>% 
@@ -1717,7 +1711,9 @@ QProMS <- R6Class(
       
       if(is.null(self$normalized_data)){return(NULL)}
       if(nrow(self$expdesign) == 1){return(self$plot_empty_message("Not enough samples to compute the plot."))}
-      tr_dir <- self$get_trelliscope_path("multi_scatter")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       combinations <- t(combn(self$expdesign %>% pull(label), 2))
       colnames(combinations) <- c("x", "y")
       combinations <- as_tibble(combinations)
@@ -2186,7 +2182,9 @@ QProMS <- R6Class(
     plot_volcano = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("volcano")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2211,7 +2209,9 @@ QProMS <- R6Class(
     plot_ma = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("ma")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2288,7 +2288,9 @@ QProMS <- R6Class(
       if(is.null(genes) || length(genes) == 0){
         genes <- "NO_GENE_SELECTED"
       }
-      tr_dir <- self$get_trelliscope_path("stat_profile")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       x_all_genes <- rep(tests, each = length(genes))
       x_all_contrast <- rep(genes, length(tests))
       table <- tibble(
@@ -2555,7 +2557,9 @@ QProMS <- R6Class(
     },
     plot_cluster_profile = function() {
       if(is.null(self$anova_table)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("cluster_profile")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       
       clusters <- self$anova_table %>% distinct(cluster) %>% filter(cluster != "not_defined") %>% pull()
       colors <- viridis(n = length(clusters), option = self$palette)
@@ -3053,7 +3057,9 @@ QProMS <- R6Class(
     },
     plot_ora = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("ora")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3313,7 +3319,9 @@ QProMS <- R6Class(
     },
     plot_gsea = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      tr_dir <- self$get_trelliscope_path("gsea")
+      tr_dir <- tempfile()
+      dir.create(tr_dir)
+      add_trelliscope_resource_path("trelliscope", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -924,6 +924,14 @@ QProMS <- R6Class(
         )
       return(t)
     },
+    get_trelliscope_path = function(name) {
+      root_dir <- file.path(tempdir(), "qproms_trelliscope")
+      dir.create(root_dir, showWarnings = FALSE, recursive = TRUE)
+      add_trelliscope_resource_path("trelliscope", root_dir)
+      plot_dir <- file.path(root_dir, name)
+      dir.create(plot_dir, showWarnings = FALSE, recursive = TRUE)
+      return(plot_dir)
+    },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
         e_bar(y) %>%
@@ -935,6 +943,152 @@ QProMS <- R6Class(
           color = "#555"
         ) %>%
         e_show_loading(text = "Loading...", color = self$primary_color)
+    },
+    safe_report_plot = function(plot_fn, message = "Section not available for this analysis.") {
+      tryCatch(
+        plot_fn(),
+        error = function(e) {
+          self$plot_empty_message(message)
+        }
+      )
+    },
+    safe_report_table = function(table_fn, message = "Table not available for this analysis.") {
+      tryCatch(
+        {
+          table <- table_fn()
+          if (is.null(table)) {
+            return(
+              reactable(
+                tibble(Message = message),
+                compact = TRUE,
+                searchable = FALSE,
+                pagination = FALSE
+              )
+            )
+          }
+          table
+        },
+        error = function(e) {
+          reactable(
+            tibble(Message = message),
+            compact = TRUE,
+            searchable = FALSE,
+            pagination = FALSE
+          )
+        }
+      )
+    },
+    prepare_report_outputs = function() {
+      if (is.null(self$data)) {
+        return(invisible(NULL))
+      }
+      
+      if (is.null(self$rank_data) && !is.null(self$protein_rank_target)) {
+        tryCatch(
+          self$rank_protein(
+            target = self$protein_rank_target,
+            by_condition = self$protein_rank_by_cond,
+            selection = self$protein_rank_selection,
+            n_perc = self$protein_rank_top_n
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if (isTRUE(self$with_statistics) && is.null(self$stat_table) &&
+          !is.null(self$contrasts) && length(self$contrasts) > 0) {
+        tryCatch(
+          self$stat_uni_test(
+            test = self$contrasts,
+            fc = self$fold_change,
+            alpha = self$univariate_alpha,
+            p_adj_method = self$univariate_p_adj_method,
+            paired_test = self$univariate_paired,
+            test_type = self$univariate_test_type
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if (isTRUE(self$with_statistics) && is.null(self$anova_table)) {
+        tryCatch(
+          self$stat_anova(
+            alpha = self$anova_alpha,
+            p_adj_method = self$anova_p_adj_method
+          ),
+          error = function(e) NULL
+        )
+      }
+      
+      if ((is.null(self$nodes_table) || is.null(self$edges_table)) &&
+          !is.null(self$network_from_statistic) && !is.null(self$pdb_database)) {
+        focus_net <- NULL
+        if (self$network_from_statistic == "univariate") {
+          focus_net <- self$network_focus_uni
+        } else if (self$network_from_statistic == "multivariate") {
+          focus_net <- self$network_focus_multi
+        } else if (self$network_from_statistic == "top_rank") {
+          focus_net <- "top_rank"
+        }
+        
+        tryCatch(
+          self$make_nodes(
+            list_from = self$network_from_statistic,
+            focus = focus_net,
+            direction = self$network_uni_direction
+          ),
+          error = function(e) NULL
+        )
+        tryCatch(
+          self$make_edges(source = self$pdb_database),
+          error = function(e) NULL
+        )
+      }
+      
+      if (is.null(self$ora_table) && !is.null(self$go_ora_from_statistic) &&
+          !is.null(self$go_ora_focus) && length(self$go_ora_focus) > 0) {
+        tryCatch(
+          {
+            self$go_ora(
+              list_from = self$go_ora_from_statistic,
+              focus = self$go_ora_focus,
+              database = self$go_ora_database,
+              ontology = self$go_ora_term,
+              simplify_thr = self$go_ora_simplify_thr,
+              alpha = self$go_ora_alpha,
+              p_adj_method = self$go_ora_p_adj_method,
+              min_gs_size = self$go_ora_min_gs_size,
+              max_gs_size = self$go_ora_max_gs_size,
+              background = self$go_ora_background
+            )
+            self$print_ora_table(self$go_ora_plot_arrenge)
+          },
+          error = function(e) NULL
+        )
+      }
+      
+      if (is.null(self$gsea_table) && !is.null(self$go_gsea_focus) && length(self$go_gsea_focus) > 0) {
+        tryCatch(
+          {
+            self$go_gsea(
+              test = self$go_gsea_focus,
+              rank_type = self$go_gsea_rank_with,
+              by_condition = self$go_gsea_by_cond,
+              database = self$go_gsea_database,
+              ontology = self$go_gsea_term,
+              simplify_thr = self$go_gsea_simplify_thr,
+              alpha = self$go_gsea_alpha,
+              p_adj_method = self$go_gsea_p_adj_method,
+              min_gs_size = self$go_gsea_min_gs_size,
+              max_gs_size = self$go_gsea_max_gs_size
+            )
+            self$print_gsea_table(self$go_gsea_plot_arrenge)
+          },
+          error = function(e) NULL
+        )
+      }
+      
+      invisible(NULL)
     },
     plot_protein_counts = function() {
       
@@ -1205,10 +1359,7 @@ QProMS <- R6Class(
     plot_missval_distribution = function() {
       
       if(is.null(self$imputed_data)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("missval_distribution")
       
       p <- tibble("labels" = c("total", self$expdesign$label)) %>% 
         mutate(plots_panel = panel_lazy(self$plot_missval_distribution_internal)) %>% 
@@ -1280,8 +1431,30 @@ QProMS <- R6Class(
         column_to_rownames("gene_names") %>%
         as.matrix()
       
+      if (ncol(mat) < 2 || nrow(mat) == 0) {
+        return(self$plot_empty_message("Not enough data to compute PCA."))
+      }
+      
+      zero_var <- apply(mat, 2, function(x) {
+        vals <- x[!is.na(x)]
+        length(vals) == 0 || isTRUE(all.equal(stats::sd(vals), 0))
+      })
+      if (any(zero_var)) {
+        mat <- mat[, !zero_var, drop = FALSE]
+      }
+      
+      if (ncol(mat) < 2) {
+        return(self$plot_empty_message("PCA is not available because all remaining samples have constant values."))
+      }
+      
       ## perform PCA
-      pca <- prcomp(t(mat), center = TRUE, scale = TRUE) 
+      pca <- tryCatch(
+        prcomp(t(mat), center = TRUE, scale = TRUE),
+        error = function(e) NULL
+      )
+      if (is.null(pca) || is.null(pca$x) || ncol(pca$x) < 2) {
+        return(self$plot_empty_message("PCA is not available for this analysis."))
+      }
       
       ## calculate persentage of each PC
       pca_var <- pca$sdev^2
@@ -1291,7 +1464,7 @@ QProMS <- R6Class(
         label = rownames(pca$x),
         x = pca$x[, 1],
         y = pca$x[, 2],
-        z = pca$x[, 3]
+        z = if (ncol(pca$x) >= 3) pca$x[, 3] else 0
       ) %>% 
         left_join(self$expdesign, by = "label") 
       
@@ -1335,6 +1508,9 @@ QProMS <- R6Class(
           e_toolbox_feature(feature = c("saveAsImage", "restore")) %>% 
           e_show_loading(text = "Loading...", color = self$primary_color)
       }else{
+        if (ncol(pca$x) < 3) {
+          return(self$plot_empty_message("3D PCA is not available because fewer than three principal components were computed."))
+        }
         p <- pca_table %>%
           group_by(condition) %>%
           e_charts(x) %>%
@@ -1402,8 +1578,13 @@ QProMS <- R6Class(
         select(gene_names, label, intensity) %>%
         pivot_wider(id_cols = gene_names, names_from = label, values_from = intensity) %>%
         filter(if_all(.cols = everything(), .fns = ~ !is.na(.x))) %>%
-        column_to_rownames("gene_names") %>%
-        cor(method = self$cor_method) %>% 
+        column_to_rownames("gene_names")
+      
+      if (nrow(mat) == 0 || ncol(mat) < 2) {
+        return(self$plot_empty_message("Not enough complete data to compute the correlation matrix."))
+      }
+      
+      mat <- cor(mat, method = self$cor_method) %>% 
         round(digits = 2)
       
       p <- mat %>% 
@@ -1536,10 +1717,7 @@ QProMS <- R6Class(
       
       if(is.null(self$normalized_data)){return(NULL)}
       if(nrow(self$expdesign) == 1){return(self$plot_empty_message("Not enough samples to compute the plot."))}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("multi_scatter")
       combinations <- t(combn(self$expdesign %>% pull(label), 2))
       colnames(combinations) <- c("x", "y")
       combinations <- as_tibble(combinations)
@@ -1791,22 +1969,6 @@ QProMS <- R6Class(
         select(gene_names, starts_with(test)) %>%
         rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
       
-      min_thr <- table %>%
-        filter(significant) %>%
-        pull(p_val) %>%
-        max(na.rm = TRUE)
-      
-      # Creare le linee di soglia per il grafico
-      left_line <- tibble(
-        p_val = c(-log10(min_thr), -log10(min_thr), max(-log10(table$p_val), na.rm = TRUE)),
-        fold_change = c(min(table$fold_change, na.rm = TRUE), -self$fold_change, -self$fold_change)
-      )
-      
-      right_line <- tibble(
-        p_val = c(max(-log10(table$p_val), na.rm = TRUE), -log10(min_thr), -log10(min_thr)),
-        fold_change = c(self$fold_change, max(table$fold_change, na.rm = TRUE), self$fold_change)
-      )
-      
       # Preparare il grafico
       p <- table %>%
         mutate(color = case_when(
@@ -1826,10 +1988,6 @@ QProMS <- R6Class(
       }
     ")) %>%
         e_add_nested("itemStyle", color) %>%
-        e_data(left_line, fold_change) %>%
-        e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
-        e_data(right_line, fold_change) %>%
-        e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
         e_toolbox_feature(feature = c("saveAsImage", "dataZoom")) %>%
         e_x_axis(
           name = "Difference (fold change)",
@@ -1851,9 +2009,32 @@ QProMS <- R6Class(
             lineHeight = 6 * self$plot_font_size
           )
         ) %>% 
-        e_grid(containLabel = TRUE) %>%
+        e_grid(containLabel = TRUE) %>% 
         e_group("grp") %>%
         e_show_loading(text = "Loading...", color = self$primary_color)
+
+      if (any(table$significant, na.rm = TRUE)) {
+        min_thr <- table %>%
+          filter(significant) %>%
+          pull(p_val) %>%
+          max(na.rm = TRUE)
+
+        left_line <- tibble(
+          p_val = c(-log10(min_thr), -log10(min_thr), max(-log10(table$p_val), na.rm = TRUE)),
+          fold_change = c(min(table$fold_change, na.rm = TRUE), -self$fold_change, -self$fold_change)
+        )
+
+        right_line <- tibble(
+          p_val = c(max(-log10(table$p_val), na.rm = TRUE), -log10(min_thr), -log10(min_thr)),
+          fold_change = c(self$fold_change, max(table$fold_change, na.rm = TRUE), self$fold_change)
+        )
+
+        p <- p %>%
+          e_data(left_line, fold_change) %>%
+          e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8)) %>%
+          e_data(right_line, fold_change) %>%
+          e_line(p_val, legend = FALSE, color = "#000", symbol = "none", lineStyle = list(type = "dashed", width = .8))
+      }
       
       # Aggiungere punti di evidenziazione
       if (highlights_names != "") {
@@ -2005,10 +2186,7 @@ QProMS <- R6Class(
     plot_volcano = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("volcano")
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2033,10 +2211,7 @@ QProMS <- R6Class(
     plot_ma = function(tests, gene_names_marked, all_same_x, all_same_y) {
       
       if(is.null(self$stat_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("ma")
       
       if(is.null(gene_names_marked)){
         names <- ""
@@ -2113,10 +2288,7 @@ QProMS <- R6Class(
       if(is.null(genes) || length(genes) == 0){
         genes <- "NO_GENE_SELECTED"
       }
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("stat_profile")
       x_all_genes <- rep(tests, each = length(genes))
       x_all_contrast <- rep(genes, length(tests))
       table <- tibble(
@@ -2383,10 +2555,7 @@ QProMS <- R6Class(
     },
     plot_cluster_profile = function() {
       if(is.null(self$anova_table)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("cluster_profile")
       
       clusters <- self$anova_table %>% distinct(cluster) %>% filter(cluster != "not_defined") %>% pull()
       colors <- viridis(n = length(clusters), option = self$palette)
@@ -2884,10 +3053,7 @@ QProMS <- R6Class(
     },
     plot_ora = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("ora")
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3147,10 +3313,7 @@ QProMS <- R6Class(
     },
     plot_gsea = function(groups, arrange_with, show_n_category) {
       if(is.null(groups)){return(NULL)}
-      ## create the resouce path for trelliscope
-      tr_dir <- tempfile()
-      dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      tr_dir <- self$get_trelliscope_path("gsea")
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3208,9 +3371,19 @@ QProMS <- R6Class(
       addStyle(excel, sheet = name, style = body_style, rows = 2:n_row, cols = 1:n_col, gridExpand = T)
       saveWorkbook(excel, handler, overwrite = T)
     },
-    download_table = function(handler_file, table_type, table_extension, extra_columns) {
+    sanitize_export_name = function(name, limit = 31) {
+      clean <- gsub("[^A-Za-z0-9_]+", "_", name)
+      clean <- gsub("_+", "_", clean)
+      clean <- gsub("^_|_$", "", clean)
+      if (nchar(clean) == 0) {
+        clean <- "table"
+      }
+      substr(clean, 1, limit)
+    },
+    exportable_table = function(table_type, extra_columns = NULL) {
       table <- switch(
         table_type,
+        "Filtered" = self$print_table(self$filtered_data, df = TRUE),
         "Filtred" = self$print_table(self$filtered_data, df = TRUE),
         "Normalized" = self$print_table(self$normalized_data, df = TRUE),
         "Imputed" = self$print_table(self$imputed_data, df = TRUE),
@@ -3229,10 +3402,63 @@ QProMS <- R6Class(
           select(gene_names, all_of(extra_columns))
         table <- left_join(table, extra, by = "gene_names")
       }
+      table
+    },
+    download_tables = function(handler_file, table_types, table_extension, extra_columns = NULL) {
+      tables <- map(table_types, ~ self$exportable_table(.x, extra_columns = extra_columns)) %>%
+        set_names(table_types) %>%
+        compact()
+      
+      if (length(tables) == 0) {
+        return(FALSE)
+      }
+      
+      if (length(tables) == 1) {
+        table_name <- names(tables)[1]
+        self$download_table(
+          handler_file = handler_file,
+          table_type = table_name,
+          table_extension = table_extension,
+          extra_columns = extra_columns
+        )
+        return(TRUE)
+      }
+      
+      if (table_extension != ".xlsx") {
+        return("multiple_requires_xlsx")
+      }
+      
+      header_style <- createStyle(
+        fontSize = 12,
+        fontColour = "#0f0f0f",
+        fgFill = "#faf2ca",
+        halign = "center",
+        border = "TopBottomLeftRight")
+      body_style <- createStyle(
+        halign = "center",
+        border = "TopBottomLeftRight")
+      excel <- createWorkbook()
+      for (table_name in names(tables)) {
+        sheet_name <- self$sanitize_export_name(table_name)
+        table <- tables[[table_name]]
+        addWorksheet(excel, sheetName = sheet_name, gridLines = FALSE)
+        writeDataTable(excel, sheet = sheet_name, x = table, keepNA = TRUE, na.string = "NaN")
+        n_row <- nrow(table) + 1
+        n_col <- ncol(table)
+        setColWidths(excel, sheet = sheet_name, cols = 1:n_col, widths = 21)
+        addStyle(excel, sheet = sheet_name, style = header_style, rows = 1, cols = 1:n_col, gridExpand = TRUE)
+        addStyle(excel, sheet = sheet_name, style = body_style, rows = 2:n_row, cols = 1:n_col, gridExpand = TRUE)
+      }
+      saveWorkbook(excel, handler_file, overwrite = TRUE)
+      TRUE
+    },
+    download_table = function(handler_file, table_type, table_extension, extra_columns) {
+      table <- self$exportable_table(table_type, extra_columns = extra_columns)
+      if(is.null(table)) {return(NULL)}
       switch(
         table_extension,
         ".xlsx" = self$download_excel(table, table_type, handler_file),
-        ".csv" = write.csv(table, handler_file),
+        ".csv" = write.csv(table, handler_file, row.names = FALSE),
         ".tsv" = write.table(table, handler_file, sep = "\t", row.names = FALSE, quote = FALSE)
       )
     },

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -121,6 +121,8 @@ QProMS <- R6Class(
     # parameters For ORA #
     ora_result_list = NULL,
     ora_table = NULL,
+    ora_status = NULL,
+    ora_message = NULL,
     go_ora_from_statistic = NULL,
     go_ora_focus = NULL,
     go_ora_database = "GO",
@@ -502,7 +504,7 @@ QProMS <- R6Class(
           mutate(!!gene_col := str_extract(.data[[gene_col]], "[^;]*")) %>% 
           mutate(!!gene_col := make.unique(.data[[gene_col]], sep = "_"))
       } else if (self$input_type == "ProteomeDiscoverer") {
-        org_map <- inputs_type_lists$org_map
+        org_map <- self$inputs_type_lists$org_map
         org_info <- org_map[[self$organism]]
         if (is.null(org_info)) return(NULL)
         orgdb     <- org_info$orgdb
@@ -2714,7 +2716,7 @@ QProMS <- R6Class(
       edges_string_table <- NULL
       edges_corum_table <- NULL
       if(is.null(self$nodes_table)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
       if (is.null(org_info)) return(NULL)
       tax_id <- org_info$tax_id
@@ -2965,11 +2967,27 @@ QProMS <- R6Class(
       }
       return(data)
     },
+    reset_ora_feedback = function() {
+      self$ora_status <- NULL
+      self$ora_message <- NULL
+    },
+    set_ora_feedback = function(status, message) {
+      self$ora_status <- status
+      self$ora_message <- message
+    },
     go_ora = function(list_from, focus, database, ontology, simplify_thr, alpha, p_adj_method, min_gs_size, max_gs_size, background) {
-      if(is.null(focus)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      self$reset_ora_feedback()
+      self$ora_result_list <- NULL
+      if(is.null(focus)){
+        self$set_ora_feedback("warning", "No ORA input was selected.")
+        return(NULL)
+      }
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
-      if (is.null(org_info)) return(NULL)
+      if (is.null(org_info)) {
+        self$set_ora_feedback("error", "ORA could not start because the selected organism is not configured.")
+        return(NULL)
+      }
       
       orgdb     <- org_info$orgdb
       kegg_org  <- org_info$kegg
@@ -3015,25 +3033,48 @@ QProMS <- R6Class(
       if (!background) {
         uni <- NULL
       }
+      gene_vector <- map(gene_vector, ~ unique(.x[!is.na(.x) & .x != "" & .x != "NO_Significant"]))
+      gene_counts <- lengths(gene_vector)
+      empty_groups <- names(gene_vector)[gene_counts == 0]
+      if (length(empty_groups) == length(gene_vector)) {
+        self$set_ora_feedback("warning", "No significant genes were available for the selected ORA input.")
+        return(NULL)
+      }
+      gene_vector_to_run <- gene_vector[gene_counts > 0]
+      ora_errors <- character()
+      run_ora_map <- function(named_vectors, enrich_fun) {
+        imap(named_vectors, function(genes, group_name) {
+          tryCatch(
+            enrich_fun(genes),
+            error = function(e) {
+              ora_errors[[group_name]] <<- conditionMessage(e)
+              NULL
+            }
+          )
+        })
+      }
       
       if (database == "GO") {
-        self$ora_result_list <- map(gene_vector, possibly(~ enrichGO(
-          gene = .x,
-          OrgDb = orgdb,
-          keyType = 'SYMBOL',
-          ont = ontology,
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size,
-          readable = TRUE) %>% 
-            clusterProfiler::filter(p.adjust < alpha) %>% 
-            simplify(cutoff = simplify_thr), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(gene_vector_to_run, function(genes) {
+          enrichGO(
+            gene = genes,
+            OrgDb = orgdb,
+            keyType = 'SYMBOL',
+            ont = ontology,
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size,
+            readable = TRUE
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha) %>%
+            simplify(cutoff = simplify_thr)
+        })
       }
       
       if (database == "KEGG") {
         entrez <- map(
-          gene_vector,
+          gene_vector_to_run,
           ~ bitr(
             .x,
             fromType = "SYMBOL",
@@ -3041,20 +3082,23 @@ QProMS <- R6Class(
             OrgDb    = orgdb
           ) %>% pull(ENTREZID)
         )
-        self$ora_result_list <- map(entrez, possibly(~ enrichKEGG(
-          gene = .x,
-          organism = kegg_org,
-          keyType = 'kegg',
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size) %>% 
-            clusterProfiler::filter(p.adjust < alpha), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(entrez, function(genes) {
+          enrichKEGG(
+            gene = genes,
+            organism = kegg_org,
+            keyType = 'kegg',
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha)
+        })
       }
       
       if (database == "WikiPathways") {
         entrez <- map(
-          gene_vector,
+          gene_vector_to_run,
           ~ bitr(
             .x,
             fromType = "SYMBOL",
@@ -3062,20 +3106,47 @@ QProMS <- R6Class(
             OrgDb    = orgdb
           ) %>% pull(ENTREZID)
         )
-        self$ora_result_list <- map(entrez, possibly(~ enrichWP(
-          gene = .x,
-          organism = wiki_org,
-          pAdjustMethod = p_adj_method,
-          universe = uni,
-          minGSSize = min_gs_size,
-          maxGSSize = max_gs_size) %>% 
-            clusterProfiler::filter(p.adjust < alpha), otherwise = NULL))
+        self$ora_result_list <- run_ora_map(entrez, function(genes) {
+          enrichWP(
+            gene = genes,
+            organism = wiki_org,
+            pAdjustMethod = p_adj_method,
+            universe = uni,
+            minGSSize = min_gs_size,
+            maxGSSize = max_gs_size
+          ) %>%
+            clusterProfiler::filter(p.adjust < alpha)
+        })
       }
-      
+      successful_groups <- names(compact(self$ora_result_list))
+      if (length(successful_groups) == 0) {
+        if (length(ora_errors) > 0) {
+          self$set_ora_feedback(
+            "error",
+            paste0("ORA failed during enrichment: ", paste(names(ora_errors), unname(ora_errors), sep = ": ", collapse = "; "))
+          )
+        } else {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
+        return(NULL)
+      }
+      messages <- character()
+      if (length(empty_groups) > 0) {
+        messages <- c(messages, paste0("No significant genes for: ", paste(empty_groups, collapse = ", ")))
+      }
+      if (length(ora_errors) > 0) {
+        messages <- c(messages, paste0("Enrichment failed for: ", paste(names(ora_errors), collapse = ", ")))
+      }
+      if (length(messages) > 0) {
+        self$set_ora_feedback("warning", paste(messages, collapse = ". "))
+      }
     },
     print_ora_table = function(arranged_with) {
       if(length(compact(self$ora_result_list)) == 0){
         self$ora_table <- NULL
+        if (is.null(self$ora_message)) {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
         return(NULL)
       }
       results_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
@@ -3083,11 +3154,15 @@ QProMS <- R6Class(
         as_tibble()
       if(nrow(results_table) == 0) {
         self$ora_table <- NULL
+        if (is.null(self$ora_message)) {
+          self$set_ora_feedback("warning", "ORA ran successfully but no enrichment terms passed the current thresholds.")
+        }
         return(NULL)
       }
       required_cols <- c("GeneRatio", "BgRatio")
       if (!all(required_cols %in% names(results_table))) {
         self$ora_table <- NULL
+        self$set_ora_feedback("error", "ORA returned an unexpected result structure and could not be plotted.")
         return(NULL)
       }
       log_cols <- intersect(c("pvalue", "p.adjust", "qvalue"), names(results_table))
@@ -3260,7 +3335,7 @@ QProMS <- R6Class(
     },
     go_gsea = function(test, rank_type, by_condition, database, ontology, simplify_thr, alpha, p_adj_method, min_gs_size, max_gs_size) {
       if(is.null(test)){return(NULL)}
-      org_map <- inputs_type_lists$org_map
+      org_map <- self$inputs_type_lists$org_map
       org_info <- org_map[[self$organism]]
       if (is.null(org_info)) return(NULL)
       

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -363,20 +363,21 @@ QProMS <- R6Class(
       
       return(reactable(summary_table))
     },
+    get_expdesign_intensity_cols = function(intensity_type) {
+      if(self$identify_table_status == "success") {
+        if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          return(self$get_diann_sequence_intensity_cols(self$raw_data))
+        }
+        return(grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE))
+      }
+      if(is.null(intensity_type)){intensity_type <- ""}
+      intensity_type
+    },
     make_expdesign = function(intensity_type) {
       
-      if(self$identify_table_status == "success") {
-        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
-          self$get_diann_sequence_intensity_cols(self$raw_data)
-        } else {
-          grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
-        }
-      } else {
-        if(is.null(intensity_type)){intensity_type <- ""}
-        intensity_cols <- intensity_type
-      }
+      intensity_cols <- self$get_expdesign_intensity_cols(intensity_type)
       
-      visible_rows <- min(length(intensity_cols), 24)
+      visible_rows <- max(min(length(intensity_cols), 16), 6)
       table_height <- 30 + (visible_rows * 23)
       
       table <- tibble("keep" = TRUE, "condition" = "", "key" = intensity_cols) %>% 

--- a/inst/app/logic/R6Class_QProMS.R
+++ b/inst/app/logic/R6Class_QProMS.R
@@ -44,6 +44,7 @@ QProMS <- R6Class(
     input_type = NULL,
     intensity_type = NULL,
     external_genes_column = NULL,
+    diann_sequences_parser = FALSE,
     log_transform = TRUE,
     organism = NULL, 
     expdesign = NULL,
@@ -180,6 +181,7 @@ QProMS <- R6Class(
     },
     loading_data = function(input_path, input_name) {
       self$raw_data <- fread(input = input_path) 
+      self$diann_sequences_parser <- FALSE
     },
     loading_parameters = function(input_path, self, print = FALSE) {
       parameters_list <- list.load(input_path)
@@ -234,6 +236,26 @@ QProMS <- R6Class(
         return(list(status = FALSE, message = "No Intensity columns found."))
       }
     },
+    get_diann_sequence_gene_col = function(data = self$raw_data) {
+      if ("Genes" %in% colnames(data)) {
+        return("Genes")
+      }
+      if ("Gene" %in% colnames(data)) {
+        return("Gene")
+      }
+      return(NULL)
+    },
+    get_diann_sequence_intensity_cols = function(data = self$raw_data) {
+      excluded_cols <- c("N.Sequences", "N.Proteotypic.Sequences", "Genes", "Gene", "Protein.Ids")
+      intensity_cols <- colnames(data)[sapply(data, is.numeric) & !colnames(data) %in% excluded_cols]
+      return(intensity_cols)
+    },
+    identify_diann_sequence_table = function(data = self$raw_data) {
+      has_sequence_col <- "N.Sequences" %in% colnames(data)
+      gene_col <- self$get_diann_sequence_gene_col(data)
+      intensity_cols <- self$get_diann_sequence_intensity_cols(data)
+      has_sequence_col && !is.null(gene_col) && length(intensity_cols) > 0
+    },
     identify_table_type = function() {
       data <- self$raw_data
       required_columns_list <- self$inputs_type_lists$metadata_list
@@ -241,6 +263,13 @@ QProMS <- R6Class(
       table_names <- names(required_columns_list)
       
       error_messages <- list()
+
+      if (self$identify_diann_sequence_table(data)) {
+        self$identify_table_status <- "success"
+        self$input_type <- "DIA-NN"
+        self$diann_sequences_parser <- TRUE
+        return(list(status = "success", message = "Table identified: DIA-NN"))
+      }
       
       for (i in seq_along(required_columns_list)) {
         table_name <- table_names[i]
@@ -257,6 +286,7 @@ QProMS <- R6Class(
         if (required_columns_check$status && intensity_columns_check$status) {
           self$identify_table_status <- "success"
           self$input_type <- table_name
+          self$diann_sequences_parser <- FALSE
           return(list(status = "success", message = paste("Table identified:", table_name)))
         } else {
           # Collect error messages
@@ -270,10 +300,14 @@ QProMS <- R6Class(
       # If no table type matches, return the collected error messages
       self$identify_table_status <- "info"
       self$input_type <- "External"
+      self$diann_sequences_parser <- FALSE
       return(list(status = "info", messages = error_messages))
     },
     check_intensity_regex = function() {
-      regex_vec <- flatten_chr(inputs_type_lists$intensity_list %>% keep_at(self$input_type))
+      if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        return("DIA-NN sequence columns")
+      }
+      regex_vec <- flatten_chr(self$inputs_type_lists$intensity_list %>% keep_at(self$input_type))
       
       found_regex <- sapply(regex_vec, function(regex) {
         any(str_detect(colnames(self$raw_data), regex))
@@ -285,7 +319,11 @@ QProMS <- R6Class(
     create_summary_table = function() {
 
       data <- self$raw_data
-      required_columns <- inputs_type_lists$metadata_list[[self$input_type]][1]
+      required_columns <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        self$get_diann_sequence_gene_col(data)
+      } else {
+        self$inputs_type_lists$metadata_list[[self$input_type]][1]
+      }
       intensity_patterns <- self$check_intensity_regex()
       
       num_rows <- nrow(data)
@@ -299,7 +337,11 @@ QProMS <- R6Class(
       })
       
       missing_values_counts <- sapply(intensity_patterns, function(pattern) {
-        intensity_cols <- grep(pattern, colnames(data), value = TRUE)
+        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          self$get_diann_sequence_intensity_cols(data)
+        } else {
+          grep(pattern, colnames(data), value = TRUE)
+        }
         
         total_values <- length(unlist(data[, ..intensity_cols]))
         missing_values <- sum(is.na(data[, ..intensity_cols]) | data[, ..intensity_cols] == 0 | data[, ..intensity_cols] == "")
@@ -324,14 +366,21 @@ QProMS <- R6Class(
     make_expdesign = function(intensity_type) {
       
       if(self$identify_table_status == "success") {
-        intensity_cols <- grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
+        intensity_cols <- if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+          self$get_diann_sequence_intensity_cols(self$raw_data)
+        } else {
+          grep(intensity_type, colnames(self$raw_data), value = TRUE, ignore.case = FALSE)
+        }
       } else {
         if(is.null(intensity_type)){intensity_type <- ""}
         intensity_cols <- intensity_type
       }
       
+      visible_rows <- min(length(intensity_cols), 24)
+      table_height <- 30 + (visible_rows * 23)
+      
       table <- tibble("keep" = TRUE, "condition" = "", "key" = intensity_cols) %>% 
-        rhandsontable(width = "100%", stretchH = "all", height = 500) %>%
+        rhandsontable(width = "100%", stretchH = "all", height = table_height) %>%
         hot_col("key", readOnly = TRUE)
       
       return(table)
@@ -489,6 +538,14 @@ QProMS <- R6Class(
           ) %>% 
           mutate(gene_symbol = sub("_.*$", "", gene)) %>% 
           filter(!stringr::str_detect(db, "REV_")) %>% 
+          mutate(!!gene_col := self$make_unique_genes(.data[[gene_col]], .data[[protein_col]]))
+      } else if (self$input_type == "DIA-NN" && self$diann_sequences_parser) {
+        gene_col <- self$get_diann_sequence_gene_col(initial_table)
+        protein_col <- if ("Protein.Ids" %in% colnames(initial_table)) "Protein.Ids" else gene_col
+        required_columns <- unique(c(gene_col, protein_col))
+        initial_table <- initial_table %>%
+          mutate(!!gene_col := str_extract(.data[[gene_col]], "[^;]*")) %>%
+          mutate(!!protein_col := str_extract(.data[[protein_col]], "[^;]*")) %>%
           mutate(!!gene_col := self$make_unique_genes(.data[[gene_col]], .data[[protein_col]]))
       } else {
         required_columns <- inputs_type_lists$metadata_list[[self$input_type]]
@@ -923,6 +980,21 @@ QProMS <- R6Class(
           ))
         )
       return(t)
+    },
+    stat_table_for_test = function(test) {
+      if (is.null(self$stat_table) || is.null(test) || length(test) != 1 || is.na(test) || test == "") {
+        return(NULL)
+      }
+      suffixes <- c("fold_change", "p_val", "p_adj", "significant", "mean_abundance")
+      wanted <- paste0(test, "_", suffixes)
+      existing <- intersect(wanted, colnames(self$stat_table))
+      if (length(existing) == 0) {
+        return(NULL)
+      }
+      table <- self$stat_table %>%
+        select(all_of(c("gene_names", existing)))
+      names(table)[-1] <- sub(paste0(test, "_"), "", names(table)[-1], fixed = TRUE)
+      table
     },
     plot_empty_message = function(message) {
       e_charts(data.frame(x = "", y = ""), x, renderer = self$plot_format) %>%
@@ -1961,9 +2033,10 @@ QProMS <- R6Class(
         ceiling()
       
       # Preparare la tabella dei dati
-      table <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
+      table <- self$stat_table_for_test(test)
+      if (is.null(table)) {
+        return(self$plot_empty_message("Selected contrast is not available."))
+      }
       
       # Preparare il grafico
       p <- table %>%
@@ -2089,9 +2162,10 @@ QProMS <- R6Class(
         max(na.rm = TRUE) %>%
         ceiling()
       
-      table <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_")))
+      table <- self$stat_table_for_test(test)
+      if (is.null(table)) {
+        return(self$plot_empty_message("Selected contrast is not available."))
+      }
       
       p <- table %>%
         mutate(color = case_when(
@@ -2863,15 +2937,25 @@ QProMS <- R6Class(
     make_ora_list_internal = function(focus) {
       if((is.null(self$stat_table) || is.null(focus))){return(NULL)}
       test <- str_remove(focus, pattern = "_up|_down")
-      data <- self$stat_table %>%
-        select(gene_names, starts_with(test)) %>%
-        rename_at(vars(matches(test)), ~ str_remove(., paste0(test, "_"))) %>%
-        filter(significant)
+      data <- self$stat_table_for_test(test)
+      if (is.null(data) || !all(c("gene_names", "fold_change", "significant") %in% names(data))) {
+        return(tibble(
+          gene_names = c("NO_Significant", "NO_Significant"),
+          direction = c(paste0(test, "_up"), paste0(test, "_down"))
+        ))
+      }
+      data <- data %>% filter(significant)
       if(nrow(data) > 0) {
         data <- data %>%
           mutate(direction = if_else(fold_change > 0, paste0(test, "_up"), paste0(test, "_down"))) %>%
           filter(direction == focus) %>% 
           select(gene_names, direction) 
+        if (nrow(data) == 0) {
+          data <- tibble(
+            gene_names = "NO_Significant",
+            direction = focus
+          )
+        }
       } else {
         data <- tibble(
           gene_names = c("NO_Significant", "NO_Significant"),
@@ -2993,22 +3077,25 @@ QProMS <- R6Class(
         self$ora_table <- NULL
         return(NULL)
       }
-      empty <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
+      results_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
         list_rbind(names_to = "group") %>% 
-        as_tibble() %>% 
-        nrow()
-      if(empty == 0) {
+        as_tibble()
+      if(nrow(results_table) == 0) {
         self$ora_table <- NULL
         return(NULL)
       }
-      self$ora_table <- map(self$ora_result_list, ~ pluck(.x, "result")) %>%
-        list_rbind(names_to = "group") %>% 
-        as_tibble() %>% 
+      required_cols <- c("GeneRatio", "BgRatio")
+      if (!all(required_cols %in% names(results_table))) {
+        self$ora_table <- NULL
+        return(NULL)
+      }
+      log_cols <- intersect(c("pvalue", "p.adjust", "qvalue"), names(results_table))
+      self$ora_table <- results_table %>% 
         separate(GeneRatio, into = c("a", "b"), sep = "/", remove = FALSE) %>%
         separate(BgRatio, into = c("c", "d"), sep = "/", remove = FALSE) %>%
         mutate(
           fold_enrichment = (as.numeric(a) / as.numeric(b)) / (as.numeric(c) / as.numeric(d)),
-          across(c("pvalue", "p.adjust", "qvalue"), ~ round(-log10(.), 3)),
+          across(all_of(log_cols), ~ round(-log10(.), 3)),
           fold_enrichment = round(fold_enrichment, 3)
         ) %>%
         select(-c(a, b, c, d)) %>% 
@@ -3059,7 +3146,7 @@ QProMS <- R6Class(
       if(is.null(groups)){return(NULL)}
       tr_dir <- tempfile()
       dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      add_trelliscope_resource_path("trelliscope_ora", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3068,8 +3155,8 @@ QProMS <- R6Class(
       )
       p <- table %>% 
         mutate(plots_panel = panel_lazy(self$plot_ora_single)) %>% 
-        as_trelliscope_df(name = "BarPlot",
-                          path = file.path(tr_dir, "test"),
+        as_trelliscope_df(name = "ORA_BarPlot",
+                          path = file.path(tr_dir, "ora_plot"),
                           jsonp = FALSE) %>% 
         set_default_layout(ncol = n_col)
       
@@ -3321,7 +3408,7 @@ QProMS <- R6Class(
       if(is.null(groups)){return(NULL)}
       tr_dir <- tempfile()
       dir.create(tr_dir)
-      add_trelliscope_resource_path("trelliscope", tr_dir)
+      add_trelliscope_resource_path("trelliscope_gsea", tr_dir)
       if(length(groups) == 1){n_col = 1}else{n_col = 2}
       table <- tibble(
         focus = groups,
@@ -3330,8 +3417,8 @@ QProMS <- R6Class(
       )
       p <- table %>% 
         mutate(plots_panel = panel_lazy(self$plot_gsea_single)) %>% 
-        as_trelliscope_df(name = "BarPlot",
-                          path = file.path(tr_dir, "test"),
+        as_trelliscope_df(name = "GSEA_BarPlot",
+                          path = file.path(tr_dir, "gsea_plot"),
                           jsonp = FALSE) %>% 
         set_default_layout(ncol = n_col)
       

--- a/inst/app/logic/Report_QProMS.qmd
+++ b/inst/app/logic/Report_QProMS.qmd
@@ -55,6 +55,21 @@ r6 <- QProMS$new()
 # Load parameters
 rds_path <- file.path(pkg_dir, "app/logic/QProMS_session_internal.rds")
 param_list <- r6$loading_parameters(input_path = rds_path, self = r6, print = TRUE)
+r6$prepare_report_outputs()
+
+safe_panel_plots <- function(items, plot_fn, message) {
+  if (is.null(items) || length(items) == 0) {
+    return(list(placeholder = r6$plot_empty_message(message)))
+  }
+  plots <- map(
+    items,
+    ~ r6$safe_report_plot(
+      function() plot_fn(.x),
+      message = message
+    )
+  )
+  set_names(plots, items)
+}
 ```
 
 ```{r}
@@ -74,21 +89,26 @@ The following table presents an overview of the experimental design employed in 
 ```{r}
 #| label: "expdesign"
 
-r6$expdesign %>%
-  select(
-    Key = key,
-    Label = label,
-    Condition = condition,
-    Replicate = replicate
-  ) %>%
-  reactable(
-    wrap = FALSE,
-    striped = TRUE,
-    resizable = TRUE,
-    compact = TRUE,
-    height = "auto",
-    paginationType = "simple",
-  )
+r6$safe_report_table(
+  function() {
+    r6$expdesign %>%
+      select(
+        Key = key,
+        Label = label,
+        Condition = condition,
+        Replicate = replicate
+      ) %>%
+      reactable(
+        wrap = FALSE,
+        striped = TRUE,
+        resizable = TRUE,
+        compact = TRUE,
+        height = "auto",
+        paginationType = "simple"
+      )
+  },
+  message = "Experimental design is not available."
+)
 ```
 
 `r if(!params$Preprocessing) "::: {.content-hidden}"`
@@ -105,7 +125,7 @@ The following section presents a series of interactive quality control (QC) grap
 #| label: "count"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_protein_counts()
+r6$safe_report_plot(function() r6$plot_protein_counts(), "Protein counts are not available for this analysis.")
 ```
 
 ### Distribution
@@ -114,7 +134,7 @@ r6$plot_protein_counts()
 #| label: "distribution"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_distribution()
+r6$safe_report_plot(function() r6$plot_distribution(), "Distribution plot is not available for this analysis.")
 ```
 
 ### Upset Plot
@@ -123,7 +143,7 @@ r6$plot_distribution()
 #| label: "upset"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_protein_coverage()
+r6$safe_report_plot(function() r6$plot_protein_coverage(), "Upset plot is not available for this analysis.")
 ```
 
 ### CV
@@ -132,7 +152,7 @@ r6$plot_protein_coverage()
 #| label: "cv"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_cv()
+r6$safe_report_plot(function() r6$plot_cv(), "CV plot is not available for this analysis.")
 ```
 
 ### Missing Data
@@ -141,7 +161,7 @@ r6$plot_cv()
 #| label: "missing data"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_missing_data()
+r6$safe_report_plot(function() r6$plot_missing_data(), "Missing-data plot is not available for this analysis.")
 ```
 
 ### Imputed
@@ -150,7 +170,7 @@ r6$plot_missing_data()
 #| label: "imputed"
 #| eval: !expr if(params$Preprocessing) TRUE else FALSE
 
-r6$plot_missval_distribution_internal("total")
+r6$safe_report_plot(function() r6$plot_missval_distribution_internal("total"), "Imputation distribution is not available for this analysis.")
 ```
 
 :::
@@ -169,7 +189,7 @@ The x-axis (PC1) and y-axis (PC2) represent the first two principal components, 
 #| label: "pca"
 #| eval: !expr if(params$PCA) TRUE else FALSE
 
-r6$plot_pca()
+r6$safe_report_plot(function() r6$plot_pca(), "PCA is not available for this analysis.")
 ```
 
 `r if(!params$PCA) ":::"`
@@ -184,7 +204,7 @@ The following heatmap illustrates the correlation between all samples included i
 #| label: "correlation"
 #| eval: !expr if(params$Correlation) TRUE else FALSE
 
-r6$plot_correlation()
+r6$safe_report_plot(function() r6$plot_correlation(), "Correlation heatmap is not available for this analysis.")
 ```
 
 `r if(!params$Correlation) ":::"`
@@ -201,7 +221,7 @@ This plot is particularly useful for identifying highly expressed proteins that 
 #| label: "rank"
 #| eval: !expr if(params$Rank) TRUE else FALSE
 
-r6$plot_protein_rank()
+r6$safe_report_plot(function() r6$plot_protein_rank(), "Rank plot is not available for this analysis.")
 ```
 
 `r if(!params$Rank) ":::"`
@@ -224,16 +244,18 @@ This plot helps to quickly identify key proteins that are differentially express
 #| label: "volcano generation"
 #| eval: !expr if(Volcano_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$contrasts,
-  .f = ~ r6$plot_volcano_single(
-    test = .x,
-    highlights_names = "",
-    same_x = r6$univariate_same_x,
-    same_y = r6$univariate_same_y
-  )
-) %>%
-  set_names(r6$contrasts)
+plots <- safe_panel_plots(
+  r6$contrasts,
+  function(.x) {
+    r6$plot_volcano_single(
+      test = .x,
+      highlights_names = "",
+      same_x = r6$univariate_same_x,
+      same_y = r6$univariate_same_y
+    )
+  },
+  "Volcano plots are not available for this analysis."
+)
 ```
 
 ```{r}
@@ -267,7 +289,7 @@ This heatmap serves as a powerful tool for identifying proteins that are signifi
 #| label: "heatmap"
 #| eval: !expr if(Heatmap_param) TRUE else FALSE
 
-r6$plot_heatmap(order_by_expdesing = r6$anova_manual_order)
+r6$safe_report_plot(function() r6$plot_heatmap(order_by_expdesing = r6$anova_manual_order), "Heatmap is not available for this analysis.")
 ```
 
 `r if(!Heatmap_param) ":::"`
@@ -288,14 +310,17 @@ In the network visualization, edges from STRING are colored in gray, while edges
 #| label: "network"
 #| eval: !expr if(Network_param) TRUE else FALSE
 
-r6$plot_ppi_network(
-  list_from = r6$network_from_statistic,
-  score_thr = r6$network_score_thr,
-  isolate_nodes = FALSE,
-  layout = "force",
-  show_names = TRUE,
-  selected = NULL,
-  filtered = FALSE
+r6$safe_report_plot(
+  function() r6$plot_ppi_network(
+    list_from = r6$network_from_statistic,
+    score_thr = r6$network_score_thr,
+    isolate_nodes = FALSE,
+    layout = "force",
+    show_names = TRUE,
+    selected = NULL,
+    filtered = FALSE
+  ),
+  "Network plot is not available for this analysis."
 )
 ```
 
@@ -315,15 +340,17 @@ These GO terms help to contextualize the proteomic data within broader biologica
 #| label: "ora generation"
 #| eval: !expr if(ORA_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$go_ora_focus,
-  .f = ~ r6$plot_ora_single(
-    focus = .x,
-    arrange = r6$go_ora_plot_arrenge,
-    show_category = r6$go_ora_top_n
-  )
-) %>%
-  set_names(r6$go_ora_focus)
+plots <- safe_panel_plots(
+  r6$go_ora_focus,
+  function(.x) {
+    r6$plot_ora_single(
+      focus = .x,
+      arrange = r6$go_ora_plot_arrenge,
+      show_category = r6$go_ora_top_n
+    )
+  },
+  "ORA plots are not available for this analysis."
+)
 ```
 
 ```{r}
@@ -359,15 +386,17 @@ The GSEA results provide valuable insights into the biological pathways and proc
 #| label: "gsea generation"
 #| eval: !expr if(GSEA_param) TRUE else FALSE
 
-plots <- map(
-  .x = r6$go_gsea_focus,
-  .f = ~ r6$plot_gsea_single(
-    focus = .x,
-    arrange = r6$go_gsea_plot_arrenge,
-    show_category = r6$go_gsea_top_n
-  )
-) %>%
-  set_names(r6$go_gsea_focus)
+plots <- safe_panel_plots(
+  r6$go_gsea_focus,
+  function(.x) {
+    r6$plot_gsea_single(
+      focus = .x,
+      arrange = r6$go_gsea_plot_arrenge,
+      show_category = r6$go_gsea_top_n
+    )
+  },
+  "GSEA plots are not available for this analysis."
+)
 ```
 
 ```{r}

--- a/inst/app/view/download.R
+++ b/inst/app/view/download.R
@@ -1,5 +1,5 @@
 box::use(
-  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput,  checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate],
+  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput,  checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate, showNotification],
   bslib[page_fillable, layout_columns, card, card_header, card_body, accordion, accordion_panel, nav_select, tooltip],
   gargoyle[init, watch, trigger],
   quarto[quarto_render],
@@ -37,7 +37,7 @@ ui <- function(id) {
             col_widths = c(6, 3, 3),
             selectInput(
               ns("select_table"),
-              "Table",
+              "Tables",
               choices = list(
                 "Preprocessing" = c(
                   "Filtered",
@@ -58,6 +58,7 @@ ui <- function(id) {
                   "GSEA"
                 )
               ),
+              multiple = TRUE,
               width = "100%"
             ),
             selectInput(
@@ -77,8 +78,8 @@ ui <- function(id) {
             ),
             conditionalPanel(
               condition = "input.include_metadata === true &&
-                          ['Filtered','Normalized','Imputed','Volcano','Heatmap']
-                          .includes(input.select_table)",
+                          Array.isArray(input.select_table) &&
+                          input.select_table.some(x => ['Filtered','Normalized','Imputed','Volcano','Heatmap','Ranked'].includes(x))",
               ns = ns,
               selectInput(
                 ns("add_metadata"),
@@ -215,18 +216,37 @@ server <- function(id, r6) {
       }
     })
     
+    observeEvent(input$select_table, {
+      if (length(input$select_table) > 1 && !identical(input$table_extension, ".xlsx")) {
+        updateSelectInput(inputId = "table_extension", selected = ".xlsx")
+        showNotification("Multiple tables are exported together as an .xlsx workbook.", type = "message")
+      }
+    }, ignoreNULL = TRUE)
+    
     output$download_table <- downloadHandler(
       filename = function() {
-        paste0(input$select_table, "_table_", Sys.Date(), input$table_extension)
+        selected_tables <- isolate(input$select_table)
+        if (is.null(selected_tables) || length(selected_tables) == 0) {
+          return(paste0("QProMS_tables_", Sys.Date(), ".xlsx"))
+        }
+        if (length(selected_tables) == 1) {
+          return(paste0(selected_tables[[1]], "_table_", Sys.Date(), input$table_extension))
+        }
+        paste0("QProMS_tables_", Sys.Date(), ".xlsx")
       },
       content = function(file) {
        if(!is.null(r6$data)) {
-         r6$download_table(
+         ok <- r6$download_tables(
            handler_file = file,
-           table_type = input$select_table,
+           table_types = input$select_table,
            table_extension = input$table_extension,
            extra_columns = input$add_metadata
          )
+         if (identical(ok, "multiple_requires_xlsx")) {
+           showNotification("Exporting multiple tables at once is available only as an .xlsx workbook.", type = "warning")
+         } else if (!isTRUE(ok)) {
+           showNotification("No selected tables are available for export.", type = "warning")
+         }
        }
       }
     )

--- a/inst/app/view/download.R
+++ b/inst/app/view/download.R
@@ -1,5 +1,5 @@
 box::use(
-  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput,  checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate, showNotification],
+  shiny[moduleServer, observe, downloadButton, fluidPage, p, updateCheckboxGroupInput, span, uiOutput, checkboxInput, updateSelectInput, downloadHandler, NS, conditionalPanel, withProgress, incProgress, radioButtons, selectInput, actionButton, hr, h3, h4, br, div, observeEvent, req, sliderInput, checkboxGroupInput, isolate, showNotification],
   bslib[page_fillable, layout_columns, card, card_header, card_body, accordion, accordion_panel, nav_select, tooltip],
   gargoyle[init, watch, trigger],
   quarto[quarto_render],
@@ -222,19 +222,52 @@ server <- function(id, r6) {
         paste0("QProMS_tables_", Sys.Date(), ".xlsx")
       },
       content = function(file) {
-       if(!is.null(r6$data)) {
-         ok <- r6$download_tables(
-           handler_file = file,
-           table_types = input$select_table,
-           table_extension = input$table_extension,
-           extra_columns = input$add_metadata
-         )
-         if (identical(ok, "multiple_requires_xlsx")) {
-           showNotification("Exporting multiple tables at once is available only as an .xlsx workbook.", type = "warning")
-         } else if (!isTRUE(ok)) {
-           showNotification("No selected tables are available for export.", type = "warning")
-         }
-       }
+        if (is.null(r6$data)) {
+          shinyalert(
+            title = "No data loaded",
+            text  = "Please load your data before downloading a table.",
+            type  = "warning"
+          )
+          return(invisible(NULL))
+        }
+        
+        selected_tables <- input$select_table
+        if (is.null(selected_tables) || length(selected_tables) == 0) {
+          shinyalert(
+            title = "No tables selected",
+            text  = "Please select at least one table to export.",
+            type  = "warning"
+          )
+          return(invisible(NULL))
+        }
+        
+        ok <- r6$download_tables(
+          handler_file = file,
+          table_types = selected_tables,
+          table_extension = input$table_extension,
+          extra_columns = input$add_metadata
+        )
+        
+        if (identical(ok, "multiple_requires_xlsx")) {
+          showNotification("Exporting multiple tables at once is available only as an .xlsx workbook.", type = "warning")
+          return(invisible(NULL))
+        }
+        
+        if (!isTRUE(ok)) {
+          if (length(selected_tables) == 1 && is.null(get_table_from_r6(selected_tables[[1]]))) {
+            shinyalert(
+              title = "Table not available",
+              text  = paste0(
+                "The '", selected_tables[[1]], "' table has not been generated yet. ",
+                "Please complete the corresponding analysis step first."
+              ),
+              type  = "warning"
+            )
+          } else {
+            showNotification("No selected tables are available for export.", type = "warning")
+          }
+          return(invisible(NULL))
+        }
       }
     )
     

--- a/inst/app/view/ora.R
+++ b/inst/app/view/ora.R
@@ -1,5 +1,5 @@
 box::use(
-  shiny[moduleServer, NS, selectInput, br, sliderInput, actionButton, updateSliderInput, updateNumericInput, isolate, icon, observe, updateSelectInput, updateSelectizeInput, reactive, observeEvent, numericInput, conditionalPanel, selectizeInput],
+  shiny[moduleServer, NS, selectInput, br, sliderInput, actionButton, updateSliderInput, updateNumericInput, isolate, icon, observe, updateSelectInput, updateSelectizeInput, reactive, observeEvent, numericInput, conditionalPanel, selectizeInput, showNotification],
   bslib[page_sidebar, layout_columns, navset_card_underline, nav_panel, update_switch, sidebar, accordion, accordion_panel, input_switch, tooltip, input_task_button],
   gargoyle[watch, trigger],
   trelliscope[trelliscopeOutput, renderTrelliscope],
@@ -246,6 +246,22 @@ ui <- function(id) {
 #' @export
 server <- function(id, r6, main_session) {
   moduleServer(id, function(input, output, session) {
+    render_ora_outputs <- function(message = NULL) {
+      if (!is.null(message)) {
+        showNotification(message, type = "warning")
+      }
+      output$bar_plot <- renderTrelliscope({
+        focus_plot <- r6$go_ora_focus
+        if (is.null(focus_plot) || length(focus_plot) == 0) {
+          focus_plot <- "manual"
+        }
+        if(r6$go_ora_from_statistic == "manual") {focus_plot <- "manual"}
+        r6$plot_ora(focus_plot, r6$go_ora_plot_arrenge, r6$go_ora_top_n)
+      })
+      output$table <- renderReactable({
+        r6$reactable_functional_analysis(r6$ora_table)
+      })
+    }
     
     observe({
       watch("stat")
@@ -362,18 +378,12 @@ server <- function(id, r6, main_session) {
         )
         r6$print_ora_table(r6$go_ora_plot_arrenge)
       }, error = function(e) {
-        return(NULL)
+        r6$ora_result_list <- NULL
+        r6$ora_table <- NULL
+        render_ora_outputs("ORA could not be generated for the selected input.")
+        return(invisible(NULL))
       })
-      output$bar_plot <- renderTrelliscope({
-        if(!is.null(r6$ora_result_list)) {
-          focus_plot <- r6$go_ora_focus
-          if(r6$go_ora_from_statistic == "manual") {focus_plot <- "manual"}
-          r6$plot_ora(focus_plot, r6$go_ora_plot_arrenge, r6$go_ora_top_n)
-        }
-      })
-      output$table <- renderReactable({
-        r6$reactable_functional_analysis(r6$ora_table)
-      })
+      render_ora_outputs()
     })
   })
 }

--- a/inst/app/view/ora.R
+++ b/inst/app/view/ora.R
@@ -246,9 +246,9 @@ ui <- function(id) {
 #' @export
 server <- function(id, r6, main_session) {
   moduleServer(id, function(input, output, session) {
-    render_ora_outputs <- function(message = NULL) {
+    render_ora_outputs <- function(message = NULL, notification_type = "warning") {
       if (!is.null(message)) {
-        showNotification(message, type = "warning")
+        showNotification(message, type = notification_type)
       }
       output$bar_plot <- renderTrelliscope({
         focus_plot <- r6$go_ora_focus
@@ -380,10 +380,18 @@ server <- function(id, r6, main_session) {
       }, error = function(e) {
         r6$ora_result_list <- NULL
         r6$ora_table <- NULL
-        render_ora_outputs("ORA could not be generated for the selected input.")
+        r6$set_ora_feedback("error", paste("ORA failed:", conditionMessage(e)))
+        render_ora_outputs(r6$ora_message, "error")
         return(invisible(NULL))
       })
-      render_ora_outputs()
+      ora_status <- if (length(r6$ora_status) == 1 && !is.na(r6$ora_status)) r6$ora_status else ""
+      notification_type <- switch(
+        ora_status,
+        error = "error",
+        warning = "warning",
+        "message"
+      )
+      render_ora_outputs(r6$ora_message, notification_type)
     })
   })
 }

--- a/inst/app/view/upload.R
+++ b/inst/app/view/upload.R
@@ -152,10 +152,21 @@ server <- function(id, r6, main_session) {
                 "Select Gene Column",
                 choices = colnames(r6$raw_data)[sapply(r6$raw_data, is.character)]
               ),
-              textInput(
-                ns("intensity_pattern"),
-                "Filter intensity columns (regex or keyword)",
-                placeholder = "e.g. LFQ|Intensity|Sample_"
+              layout_columns(
+                col_widths = c(9, 3),
+                textInput(
+                  ns("intensity_pattern"),
+                  "Filter intensity columns (regex or keyword)",
+                  placeholder = "e.g. LFQ|Intensity|Sample_"
+                ),
+                div(
+                  style = "margin-top: 1.8rem;",
+                  input_switch(
+                    id = ns("auto_select_pattern"),
+                    label = "Auto-select",
+                    value = TRUE
+                  )
+                )
               ),
               selectizeInput(
                 ns("intensity_columns"),
@@ -215,15 +226,21 @@ server <- function(id, r6, main_session) {
           value = TRUE,
           ignore.case = TRUE
         )
+        selected <- if (isTRUE(input$auto_select_pattern)) {
+          filtered
+        } else {
+          intersect(input$intensity_columns, filtered)
+        }
       } else {
         filtered <- all_numeric
+        selected <- intersect(input$intensity_columns, filtered)
       }
       
       updateSelectizeInput(
         session,
         "intensity_columns",
         choices = filtered,
-        selected = intersect(input$intensity_columns, filtered),
+        selected = selected,
         server = TRUE
       )
     })

--- a/inst/app/view/upload.R
+++ b/inst/app/view/upload.R
@@ -60,7 +60,10 @@ ui <- function(id) {
       nav_panel(
         title = "Experimental Design",
         layout_sidebar(
-          rHandsontableOutput(ns("exp_design")),
+          div(
+            uiOutput(ns("exp_design_info")),
+            rHandsontableOutput(ns("exp_design"))
+          ),
           sidebar = sidebar(
             width = 300,
             actionButton(
@@ -92,6 +95,8 @@ server <- function(id, r6, main_session) {
     
     ns <- session$ns
     init("genes")
+    
+    output$exp_design_info <- renderUI({NULL})
     
     observe({
       watch("session")
@@ -247,14 +252,30 @@ server <- function(id, r6, main_session) {
     
     observeEvent(input$confirm2, {
       if(!is.null(r6$raw_data) & r6$new_session) {
+        intensity_input <- if(r6$identify_table_status == "success") {
+          input$intensity_type
+        } else {
+          r6$external_genes_column <- input$metadata_column
+          input$intensity_columns
+        }
+        intensity_cols <- r6$get_expdesign_intensity_cols(intensity_input)
+        output$exp_design_info <- renderUI({
+          hint_text <- if (length(intensity_cols) > 16) {
+            "Scroll inside the table to review all rows."
+          } else {
+            "All rows fit in the current view."
+          }
+          div(
+            class = "alert alert-secondary",
+            style = "padding: 0.6rem 0.9rem; margin-bottom: 0.75rem;",
+            tags$strong(paste(length(intensity_cols), "samples in the design table")),
+            br(),
+            tags$span(hint_text)
+          )
+        })
         nav_select("upload_container", "Experimental Design")
         output$exp_design <- renderRHandsontable({
-          if(r6$identify_table_status == "success") {
-            r6$make_expdesign(input$intensity_type)
-          } else {
-            r6$external_genes_column <- input$metadata_column
-            r6$make_expdesign(input$intensity_columns)
-          }
+          r6$make_expdesign(intensity_input)
         })
       }
     })


### PR DESCRIPTION
Added direct DIA-NN sequence-table support in the core R6 logic:

detect DIA-NN sequence-style inputs automatically
derive gene and intensity columns without relying only on regex patterns
normalize semicolon-separated gene/protein identifiers before downstream analysis
Improved the experimental design editor in upload:

capped the table viewport so large designs scroll inside the grid instead of stretching the page
added an inline sample-count/status hint above the table
added smarter intensity-column filtering with optional auto-select for external-table workflows
Expanded download behavior:

support exporting multiple tables at once
force .xlsx for multi-table exports
improve filenames for single vs multi-table downloads
add clearer warnings for missing data, no selected tables, and unavailable result tables
Hardened report generation in both app and package copies:

safer loading of the packaged R6 class and session file
wrapped report tables/plots with safe fallbacks so missing outputs show placeholders instead of breaking the report
made volcano, ORA, and GSEA panel generation more defensive
Fixed volcano/stat-table handling:

added safer extraction of contrast-specific columns from stat_table
avoid plot failures when a selected contrast is missing or partially unavailable
return explicit empty-plot messages instead of erroring
Improved ORA robustness:

distinguish between “no significant genes”, “no enrichment terms passed thresholds”, and real ORA/enrichment errors
avoid passing placeholder pseudo-genes into enrichment calls
make ORA table generation tolerate partial or empty result objects more safely
surface clearer ORA notifications in the UI
Fixed ORA/package execution issues:

made organism-map lookups resolve reliably from the loaded static metadata in both R6 classes
fixed the ORA notification path so missing status values no longer crash the observer
Reduced trelliscope naming/path collisions:

gave ORA and GSEA their own resource-path names and output directories instead of reusing generic trelliscope / test
Applied the same behavioral fixes consistently to both codepaths:

app/...
inst/app/...