### PR TITLE
fix: isolate Shiny sessions and report artifacts

### DIFF
--- a/app/logic/Report_QProMS.qmd
+++ b/app/logic/Report_QProMS.qmd
@@ -30,6 +30,7 @@ params:
   Network: TRUE
   ORA: TRUE
   GSEA: TRUE
+  session_file: null
 ---
 
 This is a report summarizing the results obtained from [QProMS App](https://bioserver.ieo.it/shiny/app/qproms).
@@ -48,10 +49,11 @@ suppressPackageStartupMessages(library(reactable))
 
 box::use(app/logic/R6Class_QProMS)
 r6 <- R6Class_QProMS$QProMS$new()
-# Remove the comment below to download the report locally
-# param_list <- r6$loading_parameters(input_path = here("app/logic/QProMS_session_internal.rds"), self = r6, print = TRUE)
-# This line loads the report from the server path (for production use)
-param_list <- r6$loading_parameters(input_path = "/srv/shiny-server/app/logic/QProMS_session_internal.rds", self = r6, print = TRUE)
+session_file <- params$session_file
+if (is.null(session_file) || !nzchar(session_file) || !file.exists(session_file)) {
+  stop("A valid QProMS session file must be provided via params$session_file.")
+}
+param_list <- r6$loading_parameters(input_path = session_file, self = r6, print = TRUE)
 r6$prepare_report_outputs()
 
 safe_panel_plots <- function(items, plot_fn, message) {

--- a/app/main.R
+++ b/app/main.R
@@ -24,7 +24,7 @@ box::use(
   app/logic/R6Class_QProMS,
 )
 
-object <- R6Class_QProMS$QProMS$new()
+default_primary_color <- "#6EC1E4"
 
 #' @export
 ui <- function(id) {
@@ -33,7 +33,7 @@ ui <- function(id) {
     id = ns("top_navigation"),
     title = tags$a("QProMS", href = "?", style = "text-decoration: none; color: inherit;"),
     sidebar = NULL,
-    bg = object$primary_color,
+    bg = default_primary_color,
     gap = "1rem",
     header = list(
       tags$head(
@@ -43,9 +43,9 @@ ui <- function(id) {
         )
       )
     ),
-    theme = bs_theme(version = 5, primary = object$primary_color), 
+    theme = bs_theme(version = 5, primary = default_primary_color),
     nav_spacer(),
-    nav_panel(title = "Home", home$ui(ns("home"), primary_col = object$primary_color), style = "padding: 0 !important; margin: -1px;"),
+    nav_panel(title = "Home", home$ui(ns("home"), primary_col = default_primary_color), style = "padding: 0 !important; margin: -1px;"),
     nav_panel(title = "Design", upload$ui(ns("upload"))),
     nav_panel(title = "Preprocessing", preprocessing$ui(ns("preprocessing"))),
     nav_panel(title = "PCA", pca$ui(ns("pca"))),
@@ -65,20 +65,21 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
+    session_state <- R6Class_QProMS$QProMS$new()
     ## Expand Shiny limits for upload
     options(shiny.maxRequestSize=10000*1024^2)
     ## Load modules server
-    home$server("home", r6 = object, main_session = session)
-    upload$server("upload", r6 = object, main_session = session)
-    preprocessing$server("preprocessing", r6 = object)
-    pca$server("pca", r6 = object)
-    correlation$server("correlation", r6 = object)
-    rank$server("rank", r6 = object)
-    network$server("network", r6 = object, main_session = session)
-    ora$server("ora", r6 = object, main_session = session)
-    gsea$server("gsea", r6 = object, main_session = session)
-    download$server("download", r6 = object)
-    settings$server("settings", r6 = object, main_session = session)
-    help$server("help", r6 = object, main_session = session)
+    home$server("home", r6 = session_state, main_session = session)
+    upload$server("upload", r6 = session_state, main_session = session)
+    preprocessing$server("preprocessing", r6 = session_state)
+    pca$server("pca", r6 = session_state)
+    correlation$server("correlation", r6 = session_state)
+    rank$server("rank", r6 = session_state)
+    network$server("network", r6 = session_state, main_session = session)
+    ora$server("ora", r6 = session_state, main_session = session)
+    gsea$server("gsea", r6 = session_state, main_session = session)
+    download$server("download", r6 = session_state)
+    settings$server("settings", r6 = session_state, main_session = session)
+    help$server("help", r6 = session_state, main_session = session)
   })
 }

--- a/app/view/download.R
+++ b/app/view/download.R
@@ -150,6 +150,34 @@ server <- function(id, r6) {
     
     report_file <- reactiveVal(NULL)
     
+    cleanup_generated_report <- function(path) {
+      if (is.null(path) || !nzchar(path)) {
+        return(invisible(NULL))
+      }
+
+      report_dir <- dirname(path)
+      temp_root <- normalizePath(tempdir(), mustWork = TRUE)
+      report_dir_norm <- normalizePath(report_dir, mustWork = FALSE)
+      is_temp_child <- startsWith(report_dir_norm, paste0(temp_root, .Platform$file.sep))
+
+      if (is_temp_child && dir.exists(report_dir_norm)) {
+        unlink(report_dir_norm, recursive = TRUE, force = TRUE)
+      } else if (file.exists(path)) {
+        unlink(path, force = TRUE)
+      }
+
+      invisible(NULL)
+    }
+
+    reset_report_file <- function() {
+      cleanup_generated_report(report_file())
+      report_file(NULL)
+    }
+
+    session$onSessionEnded(function() {
+      cleanup_generated_report(report_file())
+    })
+
     output$report_controls <- renderUI({
       generated_report <- report_file()
       report_ready <- !is.null(generated_report) && file.exists(generated_report)
@@ -193,7 +221,7 @@ server <- function(id, r6) {
     observeEvent(
       list(input$report_preset, input$report_section),
       {
-        report_file(NULL)
+        reset_report_file()
       },
       ignoreInit = TRUE
     )
@@ -311,7 +339,7 @@ server <- function(id, r6) {
     )
     
     observeEvent(input$generate_report, {
-      report_file(NULL)
+      reset_report_file()
       
       if (is.null(r6$data)) {
         shinyalert(
@@ -332,7 +360,11 @@ server <- function(id, r6) {
         
         incProgress(1/5, message = "Saving session")
         
-        session_file <- "/srv/shiny-server/app/logic/QProMS_session_internal.rds"
+        app_root <- normalizePath(getwd(), mustWork = TRUE)
+        report_qmd <- file.path(app_root, "app/logic/Report_QProMS.qmd")
+        session_file <- tempfile("QProMS_session_", fileext = ".rds")
+        on.exit(unlink(session_file, force = TRUE), add = TRUE)
+
         r6$download_parameters(
           handler_file = session_file,
           r6class = r6
@@ -348,6 +380,7 @@ server <- function(id, r6) {
             set_names(params)
         }
         
+        param_list <- c(param_list, list(session_file = session_file))
         print(param_list)
         
         incProgress(
@@ -356,39 +389,42 @@ server <- function(id, r6) {
           detail = "This operation can take some time."
         )
         
-        source_report <- "/srv/shiny-server/app/logic/Report_QProMS.html"
+        render_dir <- tempfile("QProMS_report_")
+        dir.create(render_dir)
+        render_committed <- FALSE
+        on.exit({
+          if (!isTRUE(render_committed)) {
+            unlink(render_dir, recursive = TRUE, force = TRUE)
+          }
+        }, add = TRUE)
         
-        if (file.exists(source_report)) {
-          file.remove(source_report)
-        }
+        output_file <- paste0(
+          "QProMS_report_",
+          Sys.getpid(),
+          "_",
+          as.integer(Sys.time()),
+          ".html"
+        )
         
         quarto_render(
-          input = "/srv/shiny-server/app/logic/Report_QProMS.qmd",
+          input = report_qmd,
+          output_file = output_file,
+          output_dir = render_dir,
           execute_params = param_list,
           quiet = FALSE,
-          execute_dir = "/srv/shiny-server"
+          execute_dir = app_root
         )
         
         incProgress(1/5, message = "Finalizing report")
         
-        if (!file.exists(source_report)) {
-          stop("Report HTML was not created: ", source_report)
+        generated_report <- file.path(render_dir, output_file)
+        
+        if (!file.exists(generated_report)) {
+          stop("Report HTML was not created: ", generated_report)
         }
         
-        tmp_report <- file.path(
-          tempdir(),
-          paste0("QProMS_report_", Sys.getpid(), "_", as.integer(Sys.time()), ".html")
-        )
-        
-        ok <- file.copy(source_report, tmp_report, overwrite = TRUE)
-        
-        if (!isTRUE(ok) || !file.exists(tmp_report)) {
-          stop("Failed to copy report to temporary file: ", tmp_report)
-        }
-        
-        file.remove(source_report)
-        
-        report_file(tmp_report)
+        report_file(generated_report)
+        render_committed <- TRUE
         
         showNotification(
           "Report generated successfully. You can now download it.",

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,13 +1,20 @@
 box::use(
-  shiny[testServer],
-  testthat[expect_true, test_that],
-)
-box::use(
-  app/main[server, ui],
+  testthat[expect_false, expect_true, test_that],
 )
 
-test_that("main server works", {
-  testServer(server, {
-    expect_true(grepl(x = output$message$html, pattern = "Check out Rhino docs!"))
-  })
+test_that("QProMS state is created per Shiny session", {
+  main_source <- readLines("app/main.R", warn = FALSE)
+
+  expect_false(any(grepl("^object <- R6Class_QProMS\\$QProMS\\$new\\(\\)", main_source)))
+  expect_true(any(grepl("session_state <- R6Class_QProMS\\$QProMS\\$new\\(\\)", main_source)))
+})
+
+test_that("report generation does not use shared app-tree artifacts", {
+  download_source <- readLines("app/view/download.R", warn = FALSE)
+  report_source <- readLines("app/logic/Report_QProMS.qmd", warn = FALSE)
+
+  expect_false(any(grepl("QProMS_session_internal\\.rds", c(download_source, report_source))))
+  expect_false(any(grepl("Report_QProMS\\.html", download_source)))
+  expect_true(any(grepl("session_file <- tempfile", download_source, fixed = TRUE)))
+  expect_true(any(grepl("params\\$session_file", report_source)))
 })


### PR DESCRIPTION
## Summary

- Create a fresh `QProMS` R6 state object for each Shiny session instead of sharing one module-level instance across all users.
- Keep the UI theme color as a static default so the UI no longer requires a mutable global app state object.
- Render reports from per-session temporary `.rds` and HTML files instead of fixed files under `app/logic`.
- Clean generated report artifacts when a report is regenerated or when the Shiny session ends.
- Replace the stale scaffold test with regression checks for session-scoped state and report artifact isolation.

## Security impact

The previous global R6 object and fixed report paths made user data and generated reports process-global in multi-user deployments. Concurrent or sequential users could overwrite, corrupt, or receive another user's analysis state or report output.

## Test plan

- `git diff --check`
- Dockerized R 4.3.2 syntax/static regression check:
  - image: `rocker/r-ver:4.3.2`
  - disabled project autoloading with `R_PROFILE_USER=/dev/null` and `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE`
  - parsed:
    - `app/main.R`
    - `app/view/download.R`
    - `app/logic/R6Class_QProMS.R`
    - `tests/testthat/test-main.R`
  - asserted:
    - no global `QProMS$new()` object remains in `app/main.R`;
    - session state is created inside the server session;
    - report rendering no longer references `QProMS_session_internal.rds`, `Report_QProMS.html`, or `/srv/shiny-server/app/logic` as writable artifact paths.

Observed result: `PR #69 Docker R verification passed`.
