### PR TITLE
fix: harden uploads and session restore

### DIFF
--- a/app/logic/R6Class_QProMS.R
+++ b/app/logic/R6Class_QProMS.R
@@ -187,8 +187,73 @@ QProMS <- R6Class(
       self$raw_data <- fread(input = input_path) 
       self$diann_sequences_parser <- FALSE
     },
+    restorable_slots = function() {
+      slot_classes <- sapply(self, function(value) class(value)[1])
+      names(slot_classes)[!slot_classes %in% c("environment", "function")]
+    },
+    validate_parameters_list = function(parameters_list) {
+      if (!is.list(parameters_list)) {
+        stop("Invalid QProMS session file: expected a named list.", call. = FALSE)
+      }
+
+      parameter_names <- names(parameters_list)
+      if (is.null(parameter_names) || any(is.na(parameter_names) | !nzchar(parameter_names))) {
+        stop("Invalid QProMS session file: all entries must be named.", call. = FALSE)
+      }
+
+      unknown_parameters <- setdiff(parameter_names, self$restorable_slots())
+      if (length(unknown_parameters) > 0) {
+        stop(
+          paste0(
+            "Invalid QProMS session file: unknown entries are not allowed (",
+            paste(unknown_parameters, collapse = ", "),
+            ")."
+          ),
+          call. = FALSE
+        )
+      }
+
+      contains_unsafe_object <- function(value) {
+        if (is.function(value) || is.environment(value) || identical(typeof(value), "externalptr")) {
+          return(TRUE)
+        }
+        if (is.list(value)) {
+          return(any(vapply(value, contains_unsafe_object, logical(1))))
+        }
+        FALSE
+      }
+
+      unsafe_parameters <- parameter_names[vapply(parameters_list, contains_unsafe_object, logical(1))]
+      if (length(unsafe_parameters) > 0) {
+        stop(
+          paste0(
+            "Invalid QProMS session file: functions, environments, and external pointers ",
+            "cannot be restored (",
+            paste(unsafe_parameters, collapse = ", "),
+            ")."
+          ),
+          call. = FALSE
+        )
+      }
+
+      max_restore_mb <- getOption("qproms.maxUploadSizeMb", 500)
+      max_restore_bytes <- max_restore_mb * 1024^2
+      if (as.numeric(object.size(parameters_list)) > max_restore_bytes) {
+        stop(
+          paste0(
+            "Invalid QProMS session file: restored session exceeds the configured ",
+            max_restore_mb,
+            " MB size limit."
+          ),
+          call. = FALSE
+        )
+      }
+
+      TRUE
+    },
     loading_parameters = function(input_path, self, print = FALSE) {
-      parameters_list <- list.load(input_path)
+      parameters_list <- list.load(input_path, type = "rds")
+      self$validate_parameters_list(parameters_list)
       imap(parameters_list, ~ {self[[.y]] <- .x})
       invisible(self)
       if(print){return(parameters_list)}

--- a/app/main.R
+++ b/app/main.R
@@ -65,8 +65,16 @@ ui <- function(id) {
 #' @export
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
-    ## Expand Shiny limits for upload
-    options(shiny.maxRequestSize=10000*1024^2)
+    ## Configure upload limits. Keep the limit explicit and overrideable so
+    ## public deployments do not accept multi-GB anonymous uploads by default.
+    max_upload_mb <- suppressWarnings(as.numeric(Sys.getenv("QPROMS_MAX_UPLOAD_MB", "500")))
+    if (is.na(max_upload_mb) || max_upload_mb <= 0) {
+      max_upload_mb <- 500
+    }
+    options(
+      shiny.maxRequestSize = max_upload_mb * 1024^2,
+      qproms.maxUploadSizeMb = max_upload_mb
+    )
     ## Load modules server
     home$server("home", r6 = object, main_session = session)
     upload$server("upload", r6 = object, main_session = session)

--- a/app/view/home.R
+++ b/app/view/home.R
@@ -121,6 +121,47 @@ ui <- function(id, primary_col) {
   )
 }
 
+validate_uploaded_file <- function(upload, allowed_extensions, label) {
+  extension <- tolower(tools::file_ext(upload$name))
+  allowed_extensions <- tolower(allowed_extensions)
+  max_size_mb <- getOption("qproms.maxUploadSizeMb", 500)
+  max_size_bytes <- max_size_mb * 1024^2
+
+  if (!extension %in% allowed_extensions) {
+    shinyalert(
+      title = "Unsupported file type",
+      text = paste0(
+        "The ", label, " must use one of these extensions: ",
+        paste(paste0(".", allowed_extensions), collapse = ", "), "."
+      ),
+      size = "m",
+      closeOnClickOutside = TRUE,
+      type = "error",
+      showConfirmButton = FALSE,
+      timer = 5000
+    )
+    return(FALSE)
+  }
+
+  if (!is.null(upload$size) && upload$size > max_size_bytes) {
+    shinyalert(
+      title = "File too large",
+      text = paste0(
+        "The ", label, " is larger than the configured ",
+        max_size_mb, " MB upload limit."
+      ),
+      size = "m",
+      closeOnClickOutside = TRUE,
+      type = "error",
+      showConfirmButton = FALSE,
+      timer = 5000
+    )
+    return(FALSE)
+  }
+
+  TRUE
+}
+
 
 #' @export
 server <- function(id, r6, main_session) {
@@ -150,6 +191,9 @@ server <- function(id, r6, main_session) {
           )
         }
         req(input$upload_file)
+        if (!validate_uploaded_file(input$upload_file, c("txt", "tsv", "csv"), "dataset")) {
+          return(invisible(NULL))
+        }
         ## Load the data
         r6$loading_data(input_path = input$upload_file$datapath)
         trigger("expdesig")
@@ -168,8 +212,31 @@ server <- function(id, r6, main_session) {
           )
         }
         req(input$upload_params)
+        if (!validate_uploaded_file(input$upload_params, "rds", "analysis session")) {
+          return(invisible(NULL))
+        }
         if(!is.null(input$upload_params)) {
-          r6$loading_parameters(input_path = input$upload_params$datapath, r6)
+          restore_ok <- tryCatch(
+            {
+              r6$loading_parameters(input_path = input$upload_params$datapath, r6)
+              TRUE
+            },
+            error = function(e) {
+              shinyalert(
+                title = "Invalid session file",
+                text = conditionMessage(e),
+                size = "m",
+                closeOnClickOutside = TRUE,
+                type = "error",
+                showConfirmButton = FALSE,
+                timer = 7000
+              )
+              FALSE
+            }
+          )
+          if (!restore_ok) {
+            return(invisible(NULL))
+          }
           trigger("session", "genes")
           nav_select("top_navigation", "Preprocessing", session = main_session)
           purrr::walk(names(panels), ~ nav_remove("top_navigation", target  = .x, session = main_session))

--- a/tests/testthat/test-upload-and-restore-hardening.R
+++ b/tests/testthat/test-upload-and-restore-hardening.R
@@ -1,0 +1,24 @@
+box::use(
+  testthat[expect_false, expect_true, test_that],
+)
+
+test_that("uploads use an explicit configurable size limit", {
+  main_source <- readLines("app/main.R", warn = FALSE)
+  home_source <- readLines("app/view/home.R", warn = FALSE)
+
+  expect_false(any(grepl("10000\\*1024\\^2", main_source)))
+  expect_true(any(grepl("QPROMS_MAX_UPLOAD_MB", main_source, fixed = TRUE)))
+  expect_true(any(grepl("qproms.maxUploadSizeMb", c(main_source, home_source), fixed = TRUE)))
+  expect_true(any(grepl("validate_uploaded_file", home_source, fixed = TRUE)))
+})
+
+test_that("restored sessions are loaded only after validation", {
+  logic_source <- readLines("app/logic/R6Class_QProMS.R", warn = FALSE)
+  home_source <- readLines("app/view/home.R", warn = FALSE)
+
+  expect_true(any(grepl('list.load(input_path, type = "rds")', logic_source, fixed = TRUE)))
+  expect_true(any(grepl("validate_parameters_list", logic_source, fixed = TRUE)))
+  expect_true(any(grepl("unknown entries are not allowed", logic_source, fixed = TRUE)))
+  expect_true(any(grepl("functions, environments, and external pointers", logic_source, fixed = TRUE)))
+  expect_true(any(grepl("Invalid session file", home_source, fixed = TRUE)))
+})


### PR DESCRIPTION
## Summary

- Replace the previous ~9.77 GiB Shiny upload limit with a configurable `QPROMS_MAX_UPLOAD_MB` limit that defaults to 500 MB.
- Validate uploaded dataset/session file extensions and sizes before parsing or restoring them.
- Load saved sessions explicitly as RDS files instead of using type guessing.
- Validate restored session contents before assigning them into live R6 state:
  - reject unnamed entries;
  - reject unknown fields;
  - reject functions, environments, and external pointers;
  - reject restored sessions whose in-memory size exceeds the configured upload limit.
- Surface invalid restore failures as user-facing Shiny alerts instead of allowing unhandled state mutations.
- Add regression checks for upload-limit and session-restore hardening.

## Security impact

This reduces unauthenticated resource-exhaustion risk from oversized uploads and prevents arbitrary restored session fields from being bulk-assigned into the live application state.

## Test plan

- `git diff --check`
- Dockerized R 4.3.2 syntax/static regression check:
  - image: `rocker/r-ver:4.3.2`
  - disabled project autoloading with `R_PROFILE_USER=/dev/null` and `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE`
  - parsed:
    - `app/main.R`
    - `app/view/home.R`
    - `app/logic/R6Class_QProMS.R`
    - `tests/testthat/test-upload-and-restore-hardening.R`
  - asserted:
    - the old `10000*1024^2` upload limit is gone;
    - `QPROMS_MAX_UPLOAD_MB` and `qproms.maxUploadSizeMb` are used;
    - uploads are validated before loading;
    - sessions are loaded with `type = "rds"`;
    - restored session data is validated for unknown and unsafe entries.

Observed result: `PR #70 Docker R verification passed`.
